### PR TITLE
Add utilities to create mailto links

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.15",
-    "@types/node": "^12.0.0",
+    "@types/node": "^16.4.10",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "axios": "^0.21.1",

--- a/frontend/src/utils/emails/bodies/matching.template
+++ b/frontend/src/utils/emails/bodies/matching.template
@@ -1,0 +1,19 @@
+<subject>
+Study Partners!
+</subject>
+
+<body>
+Dear students, 
+
+We are writing to you because you have expressed interest in studying with other students. We are so glad you reached out! Studying with peers is known to be an effective learning tool, but whether you are learning online or in-person it can be challenging, especially in large classes, to find study partners. 
+
+Study partners should take it from here and get in touch with each other about when and how to study together. You can just hit “reply all” to get connected with each other. Based on student feedback from last semester- this semester we are offering study partners the opportunity to meet with LSC peer study skills tutors to help facilitate introductions and get you launched. Self-enroll in the study skills tutors’ Canvas site to see when drop-in hours are held, you can show up any time that works for your group. You can also drop in to see the study skills tutors if you have questions about getting started with your group.
+
+Due to privacy rules we are not able to disclose which classes the student(s) receiving this email are taking, but you have been matched because you expressed interest in finding study partners for the same course. So, your first group assignment will be to figure it out!
+
+Whether you will be studying together in-person or online, use the LSC’s tips for setting your group’s agenda and making the most out of studying together. Consider working together at a time when you can use course office hours or LSC tutoring to answer questions that may arise!
+
+If you’d like more info about studying together please contact LSC Study Partners lscstudypartners@cornell.edu We will be following up later in the semester to find out how it’s going.
+
+Happy studying!
+</body>

--- a/frontend/src/utils/emails/bodies/no-match-1.template
+++ b/frontend/src/utils/emails/bodies/no-match-1.template
@@ -1,0 +1,9 @@
+<subject>
+Update on your match request
+</subject>
+
+<body>
+Dear <data>, 
+
+We are writing to let you know that we are still working on finding study partners for the class you requested: <data>. We’ll be in touch soon with an update! In the meantime, the LSC website (http://lsc.cornell.edu/) offers lots of information about general study skills, learning effectively, and tutoring. 
+</body>

--- a/frontend/src/utils/emails/bodies/no-match-2.template
+++ b/frontend/src/utils/emails/bodies/no-match-2.template
@@ -1,0 +1,9 @@
+<subject>
+Follow-up: Update on your match request
+</subject>
+
+<body>
+Dear <data>, 
+
+We are writing to follow up and let you know that unfortunately we have not been successful, so far, in finding study partners for the class(es) you requested. We’ll be in touch again if another student requests study partners for your class(es). In the meantime, the LSC website (http://lsc.cornell.edu/) offers lots of information about general study skills, learning effectively, and tutoring. 
+</body>

--- a/frontend/src/utils/emails/bodies/test.template
+++ b/frontend/src/utils/emails/bodies/test.template
@@ -1,0 +1,9 @@
+<subject>
+Study Partners!
+</subject>
+
+<body>
+Dear students, 
+Hey <data>, how are you? <data>
+Happy studying!
+</body>

--- a/frontend/src/utils/emails/create-email-link.ts
+++ b/frontend/src/utils/emails/create-email-link.ts
@@ -1,6 +1,10 @@
-import { assert } from 'console'
 import parse from './template-parser'
 
+function assertEqual(expect: any, expression: any) {
+  if (expect !== expression) {
+    throw new Error(`AssertionFailure: expected ${expect}, got ${expression}`)
+  }
+}
 function constructMailtoUrl(
   receivers: string[],
   subject: string,
@@ -14,22 +18,24 @@ function constructMailtoUrl(
 }
 
 type ValidTemplates = 'matched' | 'no-match-1' | 'no-match-2'
-export default function getMailUrl(
+export default async function getMailUrl(
   receivers: string[],
   template: ValidTemplates,
   data: string[]
 ) {
   if (template === 'matched') {
-    assert(data.length === 0)
-    let { subject, body } = parse('matching.template', data)
+    assertEqual(0, data.length)
+    let { subject, body } = await parse('matching.template', data)
     return constructMailtoUrl(receivers, subject, body)
   } else if (template === 'no-match-1') {
-    assert(data.length === 2) // [student name, class]
-    let { subject, body } = parse('no-match-1.template', data)
+    assertEqual(2, data.length) // [student name, class]
+    let { subject, body } = await parse('no-match-1.template', data)
     return constructMailtoUrl(receivers, subject, body)
   } else if (template === 'no-match-2') {
-    assert(data.length === 1) // [student name]
-    let { subject, body } = parse('no-match-2.template', data)
+    assertEqual(1, data.length) // [student name]
+    let { subject, body } = await parse('no-match-2.template', data)
     return constructMailtoUrl(receivers, subject, body)
   }
 }
+
+getMailUrl([], 'matched', []).then((s) => console.log(s))

--- a/frontend/src/utils/emails/create-email-link.ts
+++ b/frontend/src/utils/emails/create-email-link.ts
@@ -1,0 +1,35 @@
+import { assert } from 'console'
+import parse from './template-parser'
+
+function constructMailtoUrl(
+  receivers: string[],
+  subject: string,
+  body: string
+): string {
+  let url = 'mailto:'
+  url += receivers.join(',')
+  url += '?subject=' + subject
+  url += '&body=' + encodeURI(body)
+  return url
+}
+
+type ValidTemplates = 'matched' | 'no-match-1' | 'no-match-2'
+export default function getMailUrl(
+  receivers: string[],
+  template: ValidTemplates,
+  data: string[]
+) {
+  if (template === 'matched') {
+    assert(data.length === 0)
+    let { subject, body } = parse('matching.template', data)
+    return constructMailtoUrl(receivers, subject, body)
+  } else if (template === 'no-match-1') {
+    assert(data.length === 2) // [student name, class]
+    let { subject, body } = parse('no-match-1.template', data)
+    return constructMailtoUrl(receivers, subject, body)
+  } else if (template === 'no-match-2') {
+    assert(data.length === 1) // [student name]
+    let { subject, body } = parse('no-match-2.template', data)
+    return constructMailtoUrl(receivers, subject, body)
+  }
+}

--- a/frontend/src/utils/emails/template-parser.ts
+++ b/frontend/src/utils/emails/template-parser.ts
@@ -1,13 +1,12 @@
 // A naive template parser for the .template email files
-import { readFileSync } from 'fs'
 
 type EmailTemplate = {
   subject: string
   body: string
 }
 
-function readFile(filename: string) {
-  return readFileSync(`./bodies/${filename}`, 'utf-8')
+async function readFile(filename: string): Promise<string> {
+  return fetch(filename).then((r) => r.text())
 }
 
 function replaceTemplateTagsUtil(
@@ -55,11 +54,11 @@ function extractBetweenTag(tagName: string, text: string) {
   return text.substring(firstIndex + tagName.length + 2, lastIndex).trim()
 }
 
-export default function parseTemplate(
+export default async function parseTemplate(
   fileName: string,
   data: string[]
-): EmailTemplate {
-  const fileText = readFile(fileName)
+): Promise<EmailTemplate> {
+  const fileText = await readFile(fileName)
   const subject = extractBetweenTag('subject', fileText)
   const body = replaceTemplateTags(extractBetweenTag('body', fileText), data)
 

--- a/frontend/src/utils/emails/template-parser.ts
+++ b/frontend/src/utils/emails/template-parser.ts
@@ -1,0 +1,70 @@
+// A naive template parser for the .template email files
+import { readFileSync } from 'fs'
+
+type EmailTemplate = {
+  subject: string
+  body: string
+}
+
+function readFile(filename: string) {
+  return readFileSync(`./bodies/${filename}`, 'utf-8')
+}
+
+function replaceTemplateTagsUtil(
+  text: string,
+  startIndex: number,
+  data: string[],
+  accum: string
+): string {
+  if (startIndex >= text.length) {
+    if (data)
+      throw new Error('Mismatch between number of tags and the data provided')
+    return accum
+  }
+
+  const replaceIndex = text.indexOf('<data>', startIndex)
+  if (replaceIndex === -1) return accum + text.slice(startIndex)
+  const dataPoint = data.shift()
+
+  const mid = text.slice(startIndex, replaceIndex)
+
+  if (!dataPoint)
+    throw new Error('Mismatch between number of tags and the data provided')
+  return replaceTemplateTagsUtil(
+    text,
+    replaceIndex + 6,
+    data,
+    accum + mid + dataPoint
+  )
+}
+
+function replaceTemplateTags(text: string, data: string[]) {
+  return replaceTemplateTagsUtil(text, 0, data, '')
+}
+
+function extractBetweenTag(tagName: string, text: string) {
+  const openTag = `<${tagName}>`,
+    closeTag = `</${tagName}>`
+  const firstIndex = text.indexOf(openTag)
+  const lastIndex = text.indexOf(closeTag)
+
+  if (firstIndex === -1 || lastIndex === -1) {
+    throw new Error(`Invalid text provided -- could not parse ${tagName}.`)
+  }
+
+  return text.substring(firstIndex + tagName.length + 2, lastIndex).trim()
+}
+
+export default function parseTemplate(
+  fileName: string,
+  data: string[]
+): EmailTemplate {
+  const fileText = readFile(fileName)
+  const subject = extractBetweenTag('subject', fileText)
+  const body = replaceTemplateTags(extractBetweenTag('body', fileText), data)
+
+  return {
+    subject,
+    body,
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,19 +1,15 @@
 {
   "extends": "./tsconfig.paths.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -21,9 +17,5 @@
     "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src",
-    "config-overrides.js",
-    "fonts.d.ts"
-  ]
+  "include": ["src", "config-overrides.js", "fonts.d.ts"]
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1930,10 +1930,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
-"@types/node@^12.0.0":
-  version "12.20.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
-  integrity sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==
+"@types/node@^16.4.10":
+  version "16.4.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.10.tgz#e57e2a54fc6da58da94b3571b1cb456d39f88597"
+  integrity sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Enable adding mailto links, which are generated based on pre-specified templates. 

How to use the templates
--
Each `.template` file will have 2 parts:
- The subject, wrapped between <subject> </subject> tags
- The body, wrapped between <body></body> tags. 

In a body tag, you can have have an arbitrary number of `<data>` tags. This is where the data passed into the `getMailUrl` function in `create-email-link.ts` will be inserted. 

Usage of `getMailUrl`
--
This is your contact point to get the mailto links with the correct recipient/subject/body email. Obviously, enter the receivers list and the template for which you want to generate an email href for (`type ValidTemplates = 'matched' | 'no-match-1' | 'no-match-2'`). The data is a string array which will directly map to the `<data>` tags you pass in. Note that the *number of <Data> tags and the length of the data array you pass in needs to be exactly the same*.

Now, in the actual email button, all you need to do is add an anchor tag in the following format: `<a href={getMailUrl(...)}> This is an email link </a>`. When you click the button, you should have your default mail client open up the correct email!!!
