### PR TITLE
Resolve course name spacing issue

### DIFF
--- a/backend/functions/course/get_course_id.js
+++ b/backend/functions/course/get_course_id.js
@@ -30,7 +30,8 @@ function constructUrl(courseCatalogName, roster = "FA21") {
   return url;
 }
 
-async function getCourseId(courseCatalogName, roster = "FA21") {
+async function getCourseId(courseCatalogNameRaw, roster = "FA21") {
+  const courseCatalogName = courseCatalogNameRaw.replace(/\s+/g, "");
   const url = constructUrl(courseCatalogName, roster);
   const response = await axios.get(url);
 
@@ -46,6 +47,7 @@ async function getCourseId(courseCatalogName, roster = "FA21") {
     throw new Error(
       `Could not find course data for class ${courseCatalogName}`
     );
+
   return classData.crseId.toString();
 }
 


### PR DESCRIPTION
this PR handles the spacing issue in course catalog names, as discussed before. The solution is to simply modify the roster API call to strip the excess spaces. This means we can now simply store whatever the client gives us into Firestore. Of course, _this means the client should be careful when sending course information_. We primarily use courseIds on the backend, not the names themselves, so whatever the client sends will be displayed on the course cards. 

Testing: 
```
>> getCourseId("CS 2110")
358546
>> getCourseId("ENGRD      2110")
358546
```