### PR TITLE
Enable Firestore emulator

### DIFF
--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -10,6 +10,7 @@
     "mock": "node utils/add-test-data.js",
     "lint": "eslint .",
     "serve": "firebase emulators:start --only functions",
+    "emulate": "firebase emulators:start --only functions,firestore",
     "shell": "firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
@@ -28,5 +29,8 @@
     "eslint": "^5.12.0",
     "eslint-plugin-promise": "^4.0.1",
     "firebase-functions-test": "^0.2.0"
+  },
+  "engines": {
+    "node": "16"
   }
 }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request enables use of the Firestore emulator in the Firebase Emulator Suite, which you can access at http://localhost:4000 when running the backend. This will let us test locally without wrecking the actual database.

The new command `npm run emulate` can be used to start the functions and firestore emulator. This is in addition to `npm run serve` that we were using previously, which only starts the cloud functions. Both are run from the backend/functions directory.

Sample of the Firestore emulator:

![Screen Shot 2022-02-28 at 18 56 08](https://user-images.githubusercontent.com/22627336/156078949-e13e886a-eed2-4990-b9ce-09083ddc8963.png)

### Notes <!-- Optional -->

Running `firebase emulators:start` will run functions, firestore, and hosting, but by default hosting runs on port 5000, which on macOS Monterey is used by the AirPlay Receiver (https://stackoverflow.com/a/70032049). We don't need to emulate hosting, so to avoid needing to remember to change computer settings we just start only functions and firestore.

I am also changing the engine that the functions run on to Node 16. Haven't tested this out with all of our code yet, but specifying explicitly is good and it allows us to use newer JavaScript features. If code does not work with Node 16, it should be updated, as it is the current active LTS. _This also appears to solve a lot of the problems with running zing-lsc backend for other developers_