### PR TITLE
Continuing off from Ansh's Mailto [PR #7]

### DIFF
--- a/frontend/public/bodies/matching.template
+++ b/frontend/public/bodies/matching.template
@@ -1,0 +1,19 @@
+<subject>
+Study Partners!
+</subject>
+
+<body>
+Dear students, 
+
+We are writing to you because you have expressed interest in studying with other students. We are so glad you reached out! Studying with peers is known to be an effective learning tool, but whether you are learning online or in-person it can be challenging, especially in large classes, to find study partners. 
+
+Study partners should take it from here and get in touch with each other about when and how to study together. You can just hit “reply all” to get connected with each other. Based on student feedback from last semester- this semester we are offering study partners the opportunity to meet with LSC peer study skills tutors to help facilitate introductions and get you launched. Self-enroll in the study skills tutors’ Canvas site to see when drop-in hours are held, you can show up any time that works for your group. You can also drop in to see the study skills tutors if you have questions about getting started with your group.
+
+Due to privacy rules we are not able to disclose which classes the student(s) receiving this email are taking, but you have been matched because you expressed interest in finding study partners for the same course. So, your first group assignment will be to figure it out!
+
+Whether you will be studying together in-person or online, use the LSC’s tips for setting your group’s agenda and making the most out of studying together. Consider working together at a time when you can use course office hours or LSC tutoring to answer questions that may arise!
+
+If you’d like more info about studying together please contact LSC Study Partners lscstudypartners@cornell.edu We will be following up later in the semester to find out how it’s going.
+
+Happy studying!
+</body>

--- a/frontend/public/bodies/no-match-1.template
+++ b/frontend/public/bodies/no-match-1.template
@@ -1,0 +1,9 @@
+<subject>
+Update on your match request
+</subject>
+
+<body>
+Dear <data>, 
+
+We are writing to let you know that we are still working on finding study partners for the class you requested: <data>. We’ll be in touch soon with an update! In the meantime, the LSC website (http://lsc.cornell.edu/) offers lots of information about general study skills, learning effectively, and tutoring. 
+</body>

--- a/frontend/public/bodies/no-match-2.template
+++ b/frontend/public/bodies/no-match-2.template
@@ -1,0 +1,10 @@
+
+<subject>
+Follow-up: Update on your match request
+</subject>
+
+<body>
+Dear <data>, 
+
+We are writing to follow up and let you know that unfortunately we have not been successful, so far, in finding study partners for the class(es) you requested. We’ll be in touch again if another student requests study partners for your class(es). In the meantime, the LSC website (http://lsc.cornell.edu/) offers lots of information about general study skills, learning effectively, and tutoring. 
+</body>

--- a/frontend/public/bodies/test.template
+++ b/frontend/public/bodies/test.template
@@ -1,0 +1,9 @@
+<subject>
+Study Partners!
+</subject>
+
+<body>
+Dear students, 
+Hey <data>, how are you? <data>
+Happy studying!
+</body>

--- a/frontend/src/utils/CreateEmailLink.ts
+++ b/frontend/src/utils/CreateEmailLink.ts
@@ -1,0 +1,48 @@
+import parse from './TemplateParser'
+export {}
+
+function assertEqual(expect: any, expression: any) {
+  if (expect !== expression) {
+    throw new Error(`AssertionFailure: expected ${expect}, got ${expression}`)
+  }
+}
+
+function constructMailtoUrl(
+  receivers: string[],
+  subject: string,
+  body: string
+): string {
+  let url = 'mailto:'
+  url += receivers.join(',')
+  url += '?subject=' + subject
+  url += '&body=' + encodeURI(body)
+  return url
+}
+
+type ValidTemplates = 'matched' | 'no-match-1' | 'no-match-2'
+
+export default async function getMailUrl(
+  receivers: string[],
+  template: ValidTemplates,
+  data: string[]
+) {
+  switch (template) {
+    case 'matched': {
+      assertEqual(0, data.length)
+      let { subject, body } = await parse('matching.template', data)
+      return constructMailtoUrl(receivers, subject, body)
+    }
+    case 'no-match-1': {
+      assertEqual(2, data.length) // [student name, class]
+      let { subject, body } = await parse('no-match-1.template', data)
+      return constructMailtoUrl(receivers, subject, body)
+    }
+    case 'no-match-2': {
+      assertEqual(1, data.length) // [student name]
+      let { subject, body } = await parse('no-match-2.template', data)
+      return constructMailtoUrl(receivers, subject, body)
+    }
+    default:
+      console.log('no template')
+  }
+}

--- a/frontend/src/utils/TemplateParser.ts
+++ b/frontend/src/utils/TemplateParser.ts
@@ -1,0 +1,68 @@
+// template parser for the .template email files
+
+type EmailTemplate = {
+  subject: string
+  body: string
+}
+
+async function readFile(filename: string): Promise<string> {
+  return fetch(filename).then((r) => r.text())
+}
+
+let err_msg = 'Mismatch between number of tags and the data provided'
+
+function replaceTemplateTagsUtil(
+  text: string,
+  startIndex: number,
+  data: string[],
+  accum: string
+): string {
+  if (startIndex >= text.length) {
+    if (data) throw new Error(err_msg)
+    return accum
+  }
+  const replaceIndex = text.indexOf('<data>', startIndex)
+  if (replaceIndex === -1) return accum + text.slice(startIndex)
+  const dataPoint = data.shift()
+
+  const mid = text.slice(startIndex, replaceIndex)
+
+  if (!dataPoint) throw new Error(err_msg)
+  return replaceTemplateTagsUtil(
+    text,
+    replaceIndex + 6,
+    data,
+    accum + mid + dataPoint
+  )
+}
+
+function replaceTemplateTags(text: string, data: string[]) {
+  return replaceTemplateTagsUtil(text, 0, data, '')
+}
+
+function extractBetweenTag(tagName: string, text: string) {
+  const openTag = `<${tagName}>`,
+    closeTag = `</${tagName}>`
+  const firstIndex = text.indexOf(openTag)
+  const lastIndex = text.indexOf(closeTag)
+
+  if (firstIndex === -1 || lastIndex === -1) {
+    throw new Error(`Invalid text prodived -- could not parse ${tagName}.`)
+  }
+
+  return text.substring(firstIndex + tagName.length + 2, lastIndex).trim()
+}
+
+export default async function parseTemplate(
+  fileName: string,
+  data: string[]
+): Promise<EmailTemplate> {
+  const fileText = await readFile(fileName)
+  const subject = extractBetweenTag('subject', fileText)
+  const body = replaceTemplateTags(extractBetweenTag('body', fileText), data)
+
+  return {
+    subject,
+    body,
+  }
+}


### PR DESCRIPTION
- change naming scheme
- change elifs to switch case statements
- move templates to public folder

### Summary <!-- Required -->

See: https://github.com/cornell-dti/zing-lsc/pull/7 

Enable adding mailto links, which are generated based on pre-specified templates. 

How to use the templates
--
Each `.template` file will have 2 parts:
- The subject, wrapped between <subject> </subject> tags
- The body, wrapped between <body></body> tags. 

In a body tag, you can have have an arbitrary number of `<data>` tags. This is where the data passed into the `getMailUrl` function in `create-email-link.ts` will be inserted. 

Usage of `getMailUrl`
--
This is your contact point to get the mailto links with the correct recipient/subject/body email. Obviously, enter the receivers list and the template for which you want to generate an email href for (`type ValidTemplates = 'matched' | 'no-match-1' | 'no-match-2'`). The data is a string array which will directly map to the `<data>` tags you pass in. Note that the *number of <Data> tags and the length of the data array you pass in needs to be exactly the same*.

Now, in the actual email button, all you need to do is add an anchor tag in the following format: `<a href={getMailUrl(...)}> This is an email link </a>`. When you click the button, you should have your default mail client open up the correct email!!!

This pull request is the first step towards implementing feature Foo

- [x] implemented X
- [ ] fixed Y

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)
