### PR TITLE
Implemented new design for empty dashboard

### DIFF
--- a/frontend/src/assets/img/noclassesicon.svg
+++ b/frontend/src/assets/img/noclassesicon.svg
@@ -1,7 +1,27 @@
-<svg width="295" height="300" viewBox="0 0 295 300" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="295" height="300" rx="30" fill="#F7EDFF"/>
-<path d="M107 236C107 222.745 117.745 212 131 212H166C179.255 212 190 222.745 190 236C190 249.255 179.255 260 166 260H131C117.745 260 107 249.255 107 236Z" fill="#E8D6FB"/>
-<rect x="65.8406" y="47.582" width="162.464" height="30.6502" rx="10" fill="#E8D6FB"/>
-<rect x="41.8984" y="116.74" width="212.058" height="23.2198" rx="10" fill="#E8D6FB"/>
-<rect x="41.8984" y="156.892" width="212.058" height="23.2198" rx="10" fill="#E8D6FB"/>
+<svg width="375" height="380" viewBox="0 0 375 380" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_dd_1131_44814)">
+<path d="M56.2 40.5H318.8C321.703 40.5 323.85 40.5004 325.545 40.6435C327.235 40.7861 328.432 41.0677 329.445 41.6042C331.128 42.4953 332.505 43.8717 333.396 45.5547C333.932 46.568 334.214 47.7649 334.356 49.4546C334.5 51.1505 334.5 53.2968 334.5 56.2V323.8C334.5 326.703 334.5 328.85 334.356 330.545C334.214 332.235 333.932 333.432 333.396 334.445C332.505 336.128 331.128 337.505 329.445 338.396C328.432 338.932 327.235 339.214 325.545 339.356C323.85 339.5 321.703 339.5 318.8 339.5H56.2C53.2968 339.5 51.1505 339.5 49.4546 339.356C47.7649 339.214 46.568 338.932 45.5547 338.396C43.8717 337.505 42.4953 336.128 41.6042 334.445C41.0677 333.432 40.7861 332.235 40.6435 330.545C40.5004 328.85 40.5 326.703 40.5 323.8V56.2C40.5 53.2968 40.5004 51.1505 40.6435 49.4546C40.7861 47.7649 41.0677 46.568 41.6042 45.5547C42.4953 43.8717 43.8717 42.4953 45.5547 41.6042C46.568 41.0677 47.7649 40.7861 49.4546 40.6435C51.1505 40.5004 53.2968 40.5 56.2 40.5Z" fill="#FBF9FF" stroke="#DBDBDD"/>
+<path d="M147 276C147 262.745 157.745 252 171 252H206C219.255 252 230 262.745 230 276V276C230 289.255 219.255 300 206 300H171C157.745 300 147 289.255 147 276V276Z" fill="#C0AEEA"/>
+<rect x="105.841" y="87.582" width="162.464" height="30.6502" rx="10" fill="#DBDBDD"/>
+<rect x="81.8984" y="156.74" width="212.058" height="23.2198" rx="10" fill="#DBDBDD"/>
+<rect x="81.8984" y="196.892" width="212.058" height="23.2198" rx="10" fill="#DBDBDD"/>
+</g>
+<defs>
+<filter id="filter0_dd_1131_44814" x="0" y="0" width="375" height="380" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="20"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1131_44814"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_1131_44814" result="effect2_dropShadow_1131_44814"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_1131_44814" result="shape"/>
+</filter>
+</defs>
 </svg>

--- a/frontend/src/modules/Dashboard/Styles/Groups.style.tsx
+++ b/frontend/src/modules/Dashboard/Styles/Groups.style.tsx
@@ -1,9 +1,16 @@
 import styled from 'styled-components'
 import { ReactComponent as NoClassesIcon } from '@assets/img/noclassesicon.svg'
-import { GenericHTMLProps, h2, StyledComponent, h3, h4 } from '@core'
+import { GenericHTMLProps, h2, h3, h4 } from '@core'
 
-const NoClasses = NoClassesIcon
-
+export const StyledNoClasses = styled(NoClassesIcon)`
+  position: static;
+  width: 375px;
+  height: 380px;
+  left: 0px;
+  top: 0px;
+  padding: 0px;
+  margin: -20px;
+`
 export const StyledContainer = styled.div`
   display: flex;
   flex: 1;
@@ -58,12 +65,4 @@ export const StyledClassesContainer = styled.div`
   padding: 5.5rem;
   flex-direction: row;
   flex-wrap: wrap;
-`
-export const StyledNoClasses = styled(NoClasses)`
-  position: static;
-  width: 295px;
-  height: 300px;
-  left: 0px;
-  top: 0px;
-  padding: 15px;
 `


### PR DESCRIPTION
### Summary <!-- Required -->
Updated the empty dashboard screen to be consistent with the new designs. This pull request implements the new empty dashboard svg. 
<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request finished implementing the dashboard screens for the Zing-LSC product.

- [x] Updated the file noclassesicon.svg to have the newly designed class card
- [x] adjusted sizing and styling to more similarly mirror the  figma designs 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

<img width="1194" alt="Screen Shot 2022-03-30 at 5 55 56 PM" src="https://user-images.githubusercontent.com/35907496/160941035-af3948b7-fdf0-4ce3-94d9-78bd93935c50.png">


### Notes <!-- Optional -->
Currently, the implementation wraps the blocks that overflow rather than keeping a grid layout that maintains fitting 4 cards in a line. 
<!--- List any important or subtle points, future considerations, or other items of note. -->

