### PR TITLE
Email sent property

### DIFF
--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -51,6 +51,9 @@ async function getStudentsForCourse(courseId: any) {
   const groupStudentData = groupStudentDataRaw.map((groupData, index) => ({
     memberData: groupData,
     groupNumber: data[index].groupNumber,
+    shareMatchEmailTimestamp: data[index].shareMatchEmailTimestamp
+      ? data[index].shareMatchEmailTimestamp.toDate()
+      : null,
   }))
 
   return {

--- a/backend/functions/src/matching/functions.ts
+++ b/backend/functions/src/matching/functions.ts
@@ -103,6 +103,7 @@ async function makeMatches(courseId: string, groupSize = 3) {
     groups.push({
       groupNumber: groupCounter + lastGroupNumber,
       memberData: nextGroup, // this is to keep things consistent
+      shareMatchEmailTimestamp: null, // timestamp for option of "share matching results"
     })
     i += nextGroup.length
     groupCounter += 1
@@ -118,6 +119,7 @@ async function makeMatches(courseId: string, groupSize = 3) {
     members: group.memberData.map((member) => member.email),
     createTime: admin.firestore.FieldValue.serverTimestamp(),
     updateTime: admin.firestore.FieldValue.serverTimestamp(),
+    shareMatchEmailTimestamp: group.shareMatchEmailTimestamp,
   }))
 
   // lastly, update the collections to reflect this matching

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -165,9 +165,13 @@ export const EditZing = () => {
       .post(`${API_ROOT}${MATCHING_API}/make`, { courseId: courseId })
       .then((response) => {
         let newGroups = studentGroups.concat(response.data.data.groups)
-        console.log(response.data.data.unmatched)
+        newGroups = newGroups.map((group: Group) => ({
+          ...group,
+          shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
+            ? new Date(group.shareMatchEmailTimestamp)
+            : null,
+        }))
         setUnmatchedStudents(response.data.data.unmatched)
-        console.log(newGroups)
         setStudentGroups(newGroups)
         setIsCurrentlyGrouping(false)
       })
@@ -202,6 +206,7 @@ export const EditZing = () => {
               key={index}
               studentList={studentGroup.memberData}
               groupNumber={studentGroup.groupNumber}
+              shareMatchEmailTimestamp={studentGroup.shareMatchEmailTimestamp}
               moveStudent={moveStudent}
             />
           ))}

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -47,7 +47,15 @@ export const EditZing = () => {
       .get(`${API_ROOT}${COURSE_API}/students/${courseId}`)
       .then((res: AxiosResponse<CourseStudentDataResponse>) => {
         setUnmatchedStudents(res.data.data.unmatched)
-        setStudentGroups(res.data.data.groups)
+        let groups = res.data.data.groups.map((group: Group) => {
+          return {
+            ...group,
+            shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
+              ? new Date(group.shareMatchEmailTimestamp)
+              : null,
+          }
+        })
+        setStudentGroups(groups)
         setHasLoadedStudentData(true)
       })
       .catch((error) => {
@@ -165,12 +173,14 @@ export const EditZing = () => {
       .post(`${API_ROOT}${MATCHING_API}/make`, { courseId: courseId })
       .then((response) => {
         let newGroups = studentGroups.concat(response.data.data.groups)
-        newGroups = newGroups.map((group: Group) => ({
-          ...group,
-          shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
-            ? new Date(group.shareMatchEmailTimestamp)
-            : null,
-        }))
+        newGroups = newGroups.map((group: Group) => {
+          return {
+            ...group,
+            shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
+              ? new Date(group.shareMatchEmailTimestamp)
+              : null,
+          }
+        })
         setUnmatchedStudents(response.data.data.unmatched)
         setStudentGroups(newGroups)
         setIsCurrentlyGrouping(false)

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -47,7 +47,7 @@ export const EditZing = () => {
       .get(`${API_ROOT}${COURSE_API}/students/${courseId}`)
       .then((res: AxiosResponse<CourseStudentDataResponse>) => {
         setUnmatchedStudents(res.data.data.unmatched)
-        let groups = res.data.data.groups.map((group: Group) => {
+        const groups = res.data.data.groups.map((group: Group) => {
           return {
             ...group,
             shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
@@ -172,17 +172,18 @@ export const EditZing = () => {
     axios
       .post(`${API_ROOT}${MATCHING_API}/make`, { courseId: courseId })
       .then((response) => {
-        let newGroups = studentGroups.concat(response.data.data.groups)
-        newGroups = newGroups.map((group: Group) => {
-          return {
-            ...group,
-            shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
-              ? new Date(group.shareMatchEmailTimestamp)
-              : null,
-          }
-        })
+        const groups = studentGroups.concat(
+          response.data.data.groups.map((group: Group) => {
+            return {
+              ...group,
+              shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
+                ? new Date(group.shareMatchEmailTimestamp)
+                : null,
+            }
+          })
+        )
         setUnmatchedStudents(response.data.data.unmatched)
-        setStudentGroups(newGroups)
+        setStudentGroups(groups)
         setIsCurrentlyGrouping(false)
       })
       .catch((err) => {

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -6,10 +6,37 @@ import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
 import {
   StyledGroupText,
-  StyledGroupTextWrapper,
   StyledGroupContainer,
 } from 'EditZing/Styles/StudentAndGroup.style'
-import { Box } from '@mui/material'
+import { Box, Tooltip } from '@mui/material'
+import CircleIcon from '@mui/icons-material/Circle'
+
+const ShareMatchEmailToolTip = ({
+  month,
+  day,
+}: {
+  month: number
+  day: number
+}) => {
+  return (
+    <Tooltip
+      title={`Share matching results: Sent on ${month}/${day}`}
+      placement="bottom-start"
+      componentsProps={{
+        tooltip: {
+          sx: {
+            bgcolor: 'essentials.main',
+            color: 'white',
+            fontWeight: 600,
+            borderRadius: '10px',
+          },
+        },
+      }}
+    >
+      <CircleIcon sx={{ fontSize: 10 }} color="primary" />
+    </Tooltip>
+  )
+}
 
 /** the equivalent of Column */
 export const GroupGrid = ({
@@ -34,20 +61,15 @@ export const GroupGrid = ({
         ref={drop}
         style={{ opacity: isOver ? '0.6' : '1' }}
       >
-        <StyledGroupTextWrapper>
-          <StyledGroupText>
-            {`Group ${groupNumber}`}
-            {shareMatchEmailTimestamp && (
-              <Box
-                component="span"
-                sx={{ color: 'primary.main', fontSize: 40 }}
-              >
-                {' '}
-                &middot;
-              </Box>
-            )}
-          </StyledGroupText>
-        </StyledGroupTextWrapper>
+        <Box display="flex" alignItems="center" mb={2}>
+          <StyledGroupText>{`Group ${groupNumber}`}</StyledGroupText>
+          {shareMatchEmailTimestamp && (
+            <ShareMatchEmailToolTip
+              month={shareMatchEmailTimestamp.getMonth() + 1}
+              day={shareMatchEmailTimestamp.getDate()}
+            />
+          )}
+        </Box>
         <Grid container spacing={2}>
           {studentList.map((student, index) => (
             <StudentGrid

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -9,12 +9,14 @@ import {
   StyledGroupTextWrapper,
   StyledGroupContainer,
 } from 'EditZing/Styles/StudentAndGroup.style'
+import { Box } from '@mui/material'
 
 /** the equivalent of Column */
 export const GroupGrid = ({
   studentList,
   groupNumber,
   moveStudent,
+  shareMatchEmailTimestamp,
 }: GroupGridProps) => {
   const [{ isOver }, drop] = useDrop({
     accept: STUDENT_TYPE,
@@ -33,7 +35,18 @@ export const GroupGrid = ({
         style={{ opacity: isOver ? '0.6' : '1' }}
       >
         <StyledGroupTextWrapper>
-          <StyledGroupText>{'Group ' + String(groupNumber)}</StyledGroupText>
+          <StyledGroupText>
+            {`Group ${groupNumber}`}
+            {shareMatchEmailTimestamp && (
+              <Box
+                component="span"
+                sx={{ color: 'primary.main', fontSize: 40 }}
+              >
+                {' '}
+                &middot;
+              </Box>
+            )}
+          </StyledGroupText>
         </StyledGroupTextWrapper>
         <Grid container spacing={2}>
           {studentList.map((student, index) => (

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -14,6 +14,7 @@ export interface UnmatchedGridProps {
 export interface GroupGridProps {
   studentList: Student[]
   groupNumber: number
+  shareMatchEmailTimestamp: Date | null
   moveStudent: (
     studentToMove: Student,
     fromGroupNumber: number,

--- a/frontend/src/modules/EditZing/Types/CourseInfo.ts
+++ b/frontend/src/modules/EditZing/Types/CourseInfo.ts
@@ -8,6 +8,7 @@ export interface CourseInfo {
 export type Group = {
   groupNumber: number
   memberData: Student[]
+  shareMatchEmailTimestamp: Date | null
 }
 
 export interface CourseInfoResponse {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request implements part 1 of the frontend email task for "newly matched", which essentially adds a new field in the database for a timestamp of when the email for "newly matched" has been sent (either the time or a null field for it hasn't been sent). The frontend takes this value in a request and displays a purple dot accordingly for whether the email has been sent or not. If the purple dot is there, that means the email has been sent and the timestamp has a value, and hovering over it will reveal the type of email sent and the date it was sent out.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

This was tested by adding data manually and testing out the two states: a null timestamp field or a filled in timestamp field (done manually). The match button was also pressed again and users were moved between groups to ensure that those functionalities would not break it.

A null timestamp:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/69130822/164551984-e0b817f9-23f8-4d98-a842-bcf65d2aea9f.png">

A non-null timestamp with the dot being hovered over, showing tooltip: 
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/69130822/164552083-04be37e3-fc4c-4b61-91fa-2487ec02ac22.png">

### Notes <!-- Optional -->

This PR does NOT add a feature to actually be able to change the field (i.e. this does not actually implement the email sending), so it must be changed manually in firebase. There will likely be merge conflicts with https://github.com/cornell-dti/zing-lsc/pull/40

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
- Database schema change: added a new field called shareMatchEmailTimestamp to the group schema.
