### PR TITLE
Edit page group selection checkboxes 

### DIFF
--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -38,16 +38,19 @@ export const EditZing = () => {
         setShowError(true)
       })
   }, [courseId])
+
   const [selectedGroups, setSelectedGroups] = useState<Group[]>([])
 
   const editSelectedGroups = (group: Group, selected: boolean) => {
     if (selected) {
       setSelectedGroups([...selectedGroups, group])
     } else {
-      setSelectedGroups(selectedGroups.filter((g) => g !== group))
+      setSelectedGroups(
+        selectedGroups.filter((g) => g.groupNumber !== group.groupNumber)
+      )
     }
   }
-  console.log(selectedGroups)
+  console.log(selectedGroups) //for seeing selected groups in console
 
   const [unmatchedStudents, setUnmatchedStudents] = useState<Student[]>([])
   const [studentGroups, setStudentGroups] = useState<Group[]>([])
@@ -250,7 +253,9 @@ export const EditZing = () => {
               moveStudent={moveStudent}
               createTime={studentGroup.createTime}
               updateTime={studentGroup.updateTime}
-              selected={selectedGroups.includes(studentGroup)}
+              selected={selectedGroups.some(
+                (g) => g.groupNumber == studentGroup.groupNumber
+              )}
               handleChecked={(event) => {
                 editSelectedGroups(studentGroup, event.target.checked)
               }}

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -21,6 +21,7 @@ import {
 import { API_ROOT, COURSE_API, MATCHING_API } from '@core/Constants'
 import { useParams } from 'react-router-dom'
 import { MatchLoading } from './MatchLoading'
+import { Box, Button } from '@mui/material'
 
 export const EditZing = () => {
   const { courseId } = useParams<{ courseId: string }>()
@@ -233,10 +234,22 @@ export const EditZing = () => {
         courseNames={courseInfo.names}
         setShowMatchLoading={setShowMatchLoading}
       />
-      <StyledLogoWrapper>
-        <StyledLogo />
-        <StyledText>{courseInfo.names.join(', ')}</StyledText>
-      </StyledLogoWrapper>
+
+      <Box
+        display="flex"
+        flex-direction="row"
+        align-items=" center"
+        justifyContent="space-between"
+      >
+        <StyledLogoWrapper>
+          <StyledLogo />
+          <StyledText>{courseInfo.names.join(', ')}</StyledText>
+        </StyledLogoWrapper>
+        s
+        <Button sx={{ height: '40px', mt: '10px' }}>
+          {selectedGroups.length == 0 ? 'Send Email To' : 'Email Selected'}
+        </Button>
+      </Box>
       <DndProvider backend={HTML5Backend}>
         <Grid container spacing={1}>
           <UnmatchedGrid

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -247,7 +247,7 @@ export const EditZing = () => {
         </StyledLogoWrapper>
         s
         <Button sx={{ height: '40px', mt: '10px' }}>
-          {selectedGroups.length == 0 ? 'Send Email To' : 'Email Selected'}
+          {selectedGroups.length === 0 ? 'Send Email To' : 'Email Selected'}
         </Button>
       </Box>
       <DndProvider backend={HTML5Backend}>
@@ -267,7 +267,7 @@ export const EditZing = () => {
               createTime={studentGroup.createTime}
               updateTime={studentGroup.updateTime}
               selected={selectedGroups.some(
-                (g) => g.groupNumber == studentGroup.groupNumber
+                (g) => g.groupNumber === studentGroup.groupNumber
               )}
               handleChecked={(event) => {
                 editSelectedGroups(studentGroup, event.target.checked)

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -38,6 +38,16 @@ export const EditZing = () => {
         setShowError(true)
       })
   }, [courseId])
+  const [selectedGroups, setSelectedGroups] = useState<Group[]>([])
+
+  const editSelectedGroups = (group: Group, selected: boolean) => {
+    if (selected) {
+      setSelectedGroups([...selectedGroups, group])
+    } else {
+      setSelectedGroups(selectedGroups.filter((g) => g !== group))
+    }
+  }
+  console.log(selectedGroups)
 
   const [unmatchedStudents, setUnmatchedStudents] = useState<Student[]>([])
   const [studentGroups, setStudentGroups] = useState<Group[]>([])
@@ -240,6 +250,10 @@ export const EditZing = () => {
               moveStudent={moveStudent}
               createTime={studentGroup.createTime}
               updateTime={studentGroup.updateTime}
+              selected={selectedGroups.includes(studentGroup)}
+              handleChecked={(event) => {
+                editSelectedGroups(studentGroup, event.target.checked)
+              }}
             />
           ))}
         </Grid>

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -62,9 +62,23 @@ export const GroupGrid = ({
     <Grid item xs={12} sm={6} md={4} lg={3}>
       <StyledGroupContainer
         ref={drop}
-        style={{ opacity: isOver ? '0.6' : '1' }}
+        style={{
+          opacity: isOver ? '0.6' : '1',
+        }}
       >
-        <Checkbox checked={selected} onChange={handleChecked} />
+        <Checkbox
+          sx={{
+            color: '#898992',
+            '&.Mui-checked': {
+              color: '#898992',
+            },
+            float: 'right',
+            width: '5 % ',
+          }}
+          checked={selected}
+          onChange={handleChecked}
+        />
+
         <Box display="flex" alignItems="center" mb={2}>
           <Tooltip
             title={

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { StudentGrid } from 'EditZing/Components/StudentGrid'
 import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
@@ -58,28 +58,37 @@ export const GroupGrid = ({
     }),
   })
 
+  const [isHovering, setIsHovering] = useState(false)
+  const handleMouseOver = () => {
+    setIsHovering(true)
+  }
+
+  const handleMouseOut = () => {
+    setIsHovering(false)
+  }
+
   return (
     <Grid item xs={12} sm={6} md={4} lg={3}>
-      <StyledGroupContainer
+      <Box
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
         ref={drop}
-        style={{
+        sx={{
+          padding: '2rem',
+          border: "0.5px solid 'purple.50'",
+          boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.07)',
+          borderRadius: '20px',
+          margin: '0.25rem',
+          backgroundColor: selected ? 'rgba(129, 94, 212, 0.15);' : 'white',
           opacity: isOver ? '0.6' : '1',
         }}
       >
-        <Checkbox
-          sx={{
-            color: '#898992',
-            '&.Mui-checked': {
-              color: '#898992',
-            },
-            float: 'right',
-            width: '5 % ',
-          }}
-          checked={selected}
-          onChange={handleChecked}
-        />
-
-        <Box display="flex" alignItems="center" mb={2}>
+        <Box
+          display="flex"
+          flex-direction="row-reverse"
+          alignItems="center"
+          mb={2}
+        >
           <Tooltip
             title={
               'Created on ' +
@@ -96,6 +105,15 @@ export const GroupGrid = ({
               day={shareMatchEmailTimestamp.getDate()}
             />
           )}
+          {selected ||
+            (isHovering && (
+              <Checkbox
+                color="secondary"
+                align-self="flex-end"
+                checked={selected}
+                onChange={handleChecked}
+              />
+            ))}
         </Box>
         <Grid container spacing={2}>
           {studentList.map((student, index) => (
@@ -107,7 +125,7 @@ export const GroupGrid = ({
             />
           ))}
         </Grid>
-      </StyledGroupContainer>
+      </Box>
     </Grid>
   )
 }

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -7,7 +7,7 @@ import {
   StyledGroupText,
   StyledGroupContainer,
 } from 'EditZing/Styles/StudentAndGroup.style'
-import { Box, Tooltip, Grid } from '@mui/material'
+import { Box, Tooltip, Grid, Checkbox } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 
 const ShareMatchEmailToolTip = ({
@@ -45,6 +45,8 @@ export const GroupGrid = ({
   createTime,
   updateTime,
   shareMatchEmailTimestamp,
+  selected,
+  handleChecked,
 }: GroupGridProps) => {
   const [{ isOver }, drop] = useDrop({
     accept: STUDENT_TYPE,
@@ -62,6 +64,7 @@ export const GroupGrid = ({
         ref={drop}
         style={{ opacity: isOver ? '0.6' : '1' }}
       >
+        <Checkbox checked={selected} onChange={handleChecked} />
         <Box display="flex" alignItems="center" mb={2}>
           <Tooltip
             title={

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -3,10 +3,7 @@ import { StudentGrid } from 'EditZing/Components/StudentGrid'
 import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
-import {
-  StyledGroupText,
-  StyledGroupContainer,
-} from 'EditZing/Styles/StudentAndGroup.style'
+import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
 import { Box, Tooltip, Grid, Checkbox } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -88,6 +88,7 @@ export const GroupGrid = ({
           flex-direction="row-reverse"
           alignItems="center"
           mb={2}
+          sx={{ width: '100%', height: '100%' }}
         >
           <Tooltip
             title={
@@ -105,15 +106,18 @@ export const GroupGrid = ({
               day={shareMatchEmailTimestamp.getDate()}
             />
           )}
-          {selected ||
-            (isHovering && (
-              <Checkbox
-                color="secondary"
-                align-self="flex-end"
-                checked={selected}
-                onChange={handleChecked}
-              />
-            ))}
+
+          <Checkbox
+            color="secondary"
+            align-self="flex-end"
+            checked={selected}
+            onChange={handleChecked}
+            sx={{
+              display: selected || isHovering ? 'block' : 'none',
+              padding: '0px',
+              ml: '45%',
+            }}
+          />
         </Box>
         <Grid container spacing={2}>
           {studentList.map((student, index) => (

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -22,6 +22,8 @@ export interface GroupGridProps {
   ) => void
   createTime: Date
   updateTime: Date
+  selected: boolean
+  handleChecked: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 
 export interface StudentGridProps {


### PR DESCRIPTION
### Summary 

This pull request is the first step towards implementing feature to highlight group selected and make checkboxes appear. I added a list of selected groups that removes and adds groups based on whether the checkbox is selected or not. I still need to implement styling the group cards based on if the groups are selected or not and changing the button from email selected and email to.

### Test Plan

Test with multiple classes and multiple groups to check whether the groups being added to the selected groups list are correct or not. Checked the values in selected groups list in the console.
<img width="860" alt="Screen Shot 2022-05-01 at 9 19 14 AM" src="https://user-images.githubusercontent.com/94809605/166147793-af11e024-dad8-4707-be08-57d6e2cef842.png">
<img width="540" alt="Screen Shot 2022-05-01 at 9 19 20 AM" src="https://user-images.githubusercontent.com/94809605/166147796-d1378f5e-cfa3-4d3f-b0bf-d0e0277e15a2.png">

### Notes 
- will need to add styling based on whether the group is checked or not
- added a selected groups in edit zing and the checkbox in group grid

### Breaking Changes 


