### PR TITLE
Initial implementation of filter matching

### DIFF
--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -18,6 +18,7 @@ export const colors = {
   verylightgreen: '#F0F9F4',
   lightgreen: '#CEF5D6',
   darkgreen: '#157E2C',
+  darkgray: '#5C5B6A',
 }
 
 // module augmentation, needed for TypeScript

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -43,43 +43,83 @@ export const Dashboard = () => {
   }, [])
   // (a,b) = -1 if a before b, 1 if a after b, 0 if equal
   function sorted(groups: CourseInfo[], menuValue: string) {
-    if (menuValue === 'newly-match-first') {
-      return [...groups].sort((a, _) => {
-        //-1 if a newly matchable and b isn't
-        if (a.lastGroupNumber === 0 && a.unmatched.length > 1) {
-          return -1
-        } else return 1
-      })
-    } else if (menuValue === 'unmatch-first') {
-      return [...groups].sort((a, _) => {
-        //-1 if a unmatchable and b isn't
-        if (a.lastGroupNumber === 0 && a.unmatched.length === 1) {
-          return -1
-        } else return 1
-      })
-    } else if (menuValue === 'match-first') {
-      return [...groups].sort((a, _) => {
-        //-1 if a matchable and b isn't
-        if (a.lastGroupNumber > 0 && a.unmatched.length > 0) {
-          return -1
-        } else return 1
-      })
-    } else if (menuValue === 'classesa-z') {
-      const sorted = [...groups].sort((a, b) => {
-        return a.names[0].localeCompare(b.names[0], undefined, {
-          numeric: true,
+    switch (menuValue) {
+      case 'newly-match-first':
+        return [...groups].sort((a, _) => {
+          //-1 if a newly matchable and b isn't
+          if (a.lastGroupNumber === 0 && a.unmatched.length > 1) {
+            return -1
+          } else return 1
         })
-      })
-      return sorted
-    } else if (menuValue === 'classesz-a') {
-      const sorted = [...groups].sort((a, b) => {
-        return b.names[0].localeCompare(a.names[0], undefined, {
-          numeric: true,
+      case 'unmatch-first':
+        return [...groups].sort((a, _) => {
+          //-1 if a unmatchable and b isn't
+          if (a.lastGroupNumber === 0 && a.unmatched.length === 1) {
+            return -1
+          } else return 1
         })
-      })
-      return sorted
-    } else return groups
+      case 'match-first':
+        return [...groups].sort((a, _) => {
+          //-1 if a matchable and b isn't
+          if (a.lastGroupNumber > 0 && a.unmatched.length > 0) {
+            return -1
+          } else return 1
+        })
+      case 'classesa-z':
+        return [...groups].sort((a, b) => {
+          return a.names[0].localeCompare(b.names[0], undefined, {
+            numeric: true,
+          })
+        })
+      case 'classesz-a':
+        return [...groups].sort((a, b) => {
+          return b.names[0].localeCompare(a.names[0], undefined, {
+            numeric: true,
+          })
+        })
+      default:
+        return groups
+    }
   }
+
+  //   }
+  //   if (menuValue === 'newly-match-first') {
+  //     return [...groups].sort((a, _) => {
+  //       //-1 if a newly matchable and b isn't
+  //       if (a.lastGroupNumber === 0 && a.unmatched.length > 1) {
+  //         return -1
+  //       } else return 1
+  //     })
+  //   } else if (menuValue === 'unmatch-first') {
+  //     return [...groups].sort((a, _) => {
+  //       //-1 if a unmatchable and b isn't
+  //       if (a.lastGroupNumber === 0 && a.unmatched.length === 1) {
+  //         return -1
+  //       } else return 1
+  //     })
+  //   } else if (menuValue === 'match-first') {
+  //     return [...groups].sort((a, _) => {
+  //       //-1 if a matchable and b isn't
+  //       if (a.lastGroupNumber > 0 && a.unmatched.length > 0) {
+  //         return -1
+  //       } else return 1
+  //     })
+  //   } else if (menuValue === 'classesa-z') {
+  //     const sorted = [...groups].sort((a, b) => {
+  //       return a.names[0].localeCompare(b.names[0], undefined, {
+  //         numeric: true,
+  //       })
+  //     })
+  //     return sorted
+  //   } else if (menuValue === 'classesz-a') {
+  //     const sorted = [...groups].sort((a, b) => {
+  //       return b.names[0].localeCompare(a.names[0], undefined, {
+  //         numeric: true,
+  //       })
+  //     })
+  //     return sorted
+  //   } else return groups
+  // }
   const handleChange = (event: SelectChangeEvent) => {
     setStatus(event.target.value)
     setGroups(sorted(groups, event.target.value))

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -16,8 +16,12 @@ import { KeyboardArrowDown } from '@mui/icons-material'
 import { logOut } from '@fire'
 import { useAuthValue } from '@auth'
 import { useHistory } from 'react-router'
+import { DropdownSelect } from '@core/Components'
+import { SelectChangeEvent, Box } from '@mui/material'
+import { UnmatchedGrid } from 'EditZing/Components/UnmatchedGrid'
 
 export const Dashboard = () => {
+  const [status, setStatus] = useState('')
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
   const history = useHistory()
@@ -38,11 +42,77 @@ export const Dashboard = () => {
       setGroups(res.data.data)
     })
   }, [])
+  // (a,b) = -1 if a before b, 1 if a after b, 0 if equal
+  function sorted(groups: CourseInfo[], menuValue: string) {
+    if (menuValue === 'newly-match-first') {
+      return [...groups].sort((a, _) => {
+        //-1 if a newly matchable and b isn't
+        if (a.lastGroupNumber === 0 && a.unmatched.length > 1) {
+          return -1
+        } else return 1
+      })
+    } else if (menuValue === 'unmatch-first') {
+      return [...groups].sort((a, _) => {
+        //-1 if a unmatchable and b isn't
+        if (a.lastGroupNumber === 0 && a.unmatched.length === 1) {
+          return -1
+        } else return 1
+      })
+    } else if (menuValue === 'match-first') {
+      return [...groups].sort((a, _) => {
+        //-1 if a matchable and b isn't
+        if (a.lastGroupNumber > 0 && a.unmatched.length > 0) {
+          return -1
+        } else return 1
+      })
+    } else if (menuValue === 'classesa-z') {
+      const sorted = [...groups].sort((a, b) => {
+        return a.names[0].localeCompare(b.names[0], undefined, {
+          numeric: true,
+        })
+      })
+      return sorted
+    } else if (menuValue === 'classesz-a') {
+      const sorted = [...groups].sort((a, b) => {
+        return b.names[0].localeCompare(a.names[0], undefined, {
+          numeric: true,
+        })
+      })
+      return sorted
+    } else return groups
+  }
+  const handleChange = (event: SelectChangeEvent) => {
+    setStatus(event.target.value)
+    setGroups(sorted(groups, event.target.value))
+  }
 
   return (
     <StyledContainer>
       <StyledHeaderMenu>
         <LogoImg />
+        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+          <Box
+            sx={{ fontWeight: 'bold', color: '#5C5B6A', padding: 1, margin: 1 }}
+          >
+            Sort by:
+          </Box>
+          <DropdownSelect
+            value={status}
+            onChange={handleChange}
+            sx={{
+              padding: 0,
+              margin: 0,
+              fontWeight: 'bold',
+            }}
+          >
+            <MenuItem value="newest">Newest</MenuItem>
+            <MenuItem value="unmatch-first">Unmatchable first</MenuItem>
+            <MenuItem value="newly-match-first">Newly matchable first</MenuItem>
+            <MenuItem value="match-first">Matchable first</MenuItem>
+            <MenuItem value="classesa-z">Classes A-Z</MenuItem>
+            <MenuItem value="classesz-a">Classes Z-A</MenuItem>
+          </DropdownSelect>
+        </Box>
         <Button
           id="logout-button"
           aria-controls="logout-menu"

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -18,7 +18,6 @@ import { useAuthValue } from '@auth'
 import { useHistory } from 'react-router'
 import { DropdownSelect } from '@core/Components'
 import { SelectChangeEvent, Box } from '@mui/material'
-import { UnmatchedGrid } from 'EditZing/Components/UnmatchedGrid'
 
 export const Dashboard = () => {
   const [status, setStatus] = useState('')

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -20,7 +20,7 @@ import { DropdownSelect } from '@core/Components'
 import { SelectChangeEvent, Box } from '@mui/material'
 
 export const Dashboard = () => {
-  const [status, setStatus] = useState('')
+  const [sortedOrder, setSortedOrder] = useState('')
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
   const history = useHistory()
@@ -86,9 +86,11 @@ export const Dashboard = () => {
   }
 
   const handleChange = (event: SelectChangeEvent) => {
-    setStatus(event.target.value)
-    setGroups(sorted(groups, event.target.value))
+    setSortedOrder(event.target.value)
+    // setGroups(sorted(groups, event.target.value))
   }
+
+  const sortedGroups = sorted(groups, sortedOrder)
 
   return (
     <StyledContainer>
@@ -96,12 +98,17 @@ export const Dashboard = () => {
         <LogoImg />
         <Box sx={{ display: 'flex', flexDirection: 'row' }}>
           <Box
-            sx={{ fontWeight: 'bold', color: '#5C5B6A', padding: 1, margin: 1 }}
+            sx={{
+              fontWeight: 'bold',
+              color: 'essentials.75',
+              padding: 1,
+              margin: 1,
+            }}
           >
             Sort by:
           </Box>
           <DropdownSelect
-            value={status}
+            value={sortedOrder}
             onChange={handleChange}
             sx={{
               padding: 0,
@@ -155,7 +162,7 @@ export const Dashboard = () => {
           </MenuItem>
         </Menu>
       </StyledHeaderMenu>
-      <Groups groups={groups} />
+      <Groups groups={sortedGroups} />
     </StyledContainer>
   )
 }

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -61,7 +61,10 @@ export const Dashboard = () => {
       case 'match-first':
         return [...groups].sort((a, _) => {
           //-1 if a matchable and b isn't
-          if (a.lastGroupNumber > 0 && a.unmatched.length > 0) {
+          if (
+            (a.lastGroupNumber > 0 && a.unmatched.length > 0) ||
+            (a.lastGroupNumber === 0 && a.unmatched.length > 1)
+          ) {
             return -1
           } else return 1
         })
@@ -82,44 +85,6 @@ export const Dashboard = () => {
     }
   }
 
-  //   }
-  //   if (menuValue === 'newly-match-first') {
-  //     return [...groups].sort((a, _) => {
-  //       //-1 if a newly matchable and b isn't
-  //       if (a.lastGroupNumber === 0 && a.unmatched.length > 1) {
-  //         return -1
-  //       } else return 1
-  //     })
-  //   } else if (menuValue === 'unmatch-first') {
-  //     return [...groups].sort((a, _) => {
-  //       //-1 if a unmatchable and b isn't
-  //       if (a.lastGroupNumber === 0 && a.unmatched.length === 1) {
-  //         return -1
-  //       } else return 1
-  //     })
-  //   } else if (menuValue === 'match-first') {
-  //     return [...groups].sort((a, _) => {
-  //       //-1 if a matchable and b isn't
-  //       if (a.lastGroupNumber > 0 && a.unmatched.length > 0) {
-  //         return -1
-  //       } else return 1
-  //     })
-  //   } else if (menuValue === 'classesa-z') {
-  //     const sorted = [...groups].sort((a, b) => {
-  //       return a.names[0].localeCompare(b.names[0], undefined, {
-  //         numeric: true,
-  //       })
-  //     })
-  //     return sorted
-  //   } else if (menuValue === 'classesz-a') {
-  //     const sorted = [...groups].sort((a, b) => {
-  //       return b.names[0].localeCompare(a.names[0], undefined, {
-  //         numeric: true,
-  //       })
-  //     })
-  //     return sorted
-  //   } else return groups
-  // }
   const handleChange = (event: SelectChangeEvent) => {
     setStatus(event.target.value)
     setGroups(sorted(groups, event.target.value))
@@ -144,7 +109,7 @@ export const Dashboard = () => {
               fontWeight: 'bold',
             }}
           >
-            <MenuItem value="newest">Newest</MenuItem>
+            {/* <MenuItem value="newest">Newest</MenuItem> */}
             <MenuItem value="unmatch-first">Unmatchable first</MenuItem>
             <MenuItem value="newly-match-first">Newly matchable first</MenuItem>
             <MenuItem value="match-first">Matchable first</MenuItem>

--- a/frontend/src/modules/Dashboard/Components/GroupCard.tsx
+++ b/frontend/src/modules/Dashboard/Components/GroupCard.tsx
@@ -45,11 +45,11 @@ export const GroupCard = ({
       return { color: colors.white, new_match: 'no' }
     }
     //students are ready to be matched
-    else if (newStudents > 0 && groupsFormed > 0) {
+    else if (students > 0 && groups > 0) {
       return { color: colors.lightgreen, new_match: 'no' }
     }
     //NEWLY MATCHABLE
-    else if (newStudents > 1 && groupsFormed === 0) {
+    else if (students > 1 && groups === 0) {
       return { color: colors.lightgreen, new_match: 'yes' }
     }
     //only 1 student & 0 groups formed


### PR DESCRIPTION
### Summary <!-- Required -->
<!-- Provide a general summary of your changes in the Title above -->
This pull request is the  first step towards implementing filtering for the class cards on the zing-lsc dashboard. It allows users to filter the  class cards available by alphabetical, reverse alphabetical, unmatchable first, newly matchable first, and matchable first. The feature for filtering by newest has still yet to be implemented. 
<!-- Itemize bug fixes, new features, and other changes -->
The filtering in this pull request is completed through customizing the   localeCompare() function and using it to sort a copied version of the groups array. The  matchability status is implemented such that a card will be sorted first if it has the   desired qualities. 
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->
<img width="741" alt="Screen Shot 2022-05-01 at 10 07 56 AM" src="https://user-images.githubusercontent.com/35907496/166149533-ec014006-94ed-481b-a1c1-2d249a94a328.png">
<img width="720" alt="Screen Shot 2022-05-01 at 10 08 08 AM" src="https://user-images.githubusercontent.com/35907496/166149541-8fe2eee7-42de-47a3-87c1-3c97cb897c4e.png">

<img width="808" alt="Screen Shot 2022-05-01 at 10 10 55 AM" src="https://user-images.githubusercontent.com/35907496/166149670-7629db3e-3dae-467b-8039-8a28113bbb8b.png">

This pull request is the first step towards implementing filter by matchability status

- [x] implemented filtering alphabetically
- [x] implemented filtering reverse alphabetically
- [x] implemented unmatchable first
- [x] implemented newly matchable first
- [x] implemented matchable first

### Test Plan <!-- Required -->

Added several iterations of each category to see if the   sorting resulted in the  right order depending on the filtering status.

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->