### PR TITLE
Dropdown email

### DIFF
--- a/frontend/src/modules/Core/Components/DropdownSelect.tsx
+++ b/frontend/src/modules/Core/Components/DropdownSelect.tsx
@@ -42,13 +42,17 @@ export const DropdownSelect = ({
           MenuListProps: {
             dense: true,
             sx: {
-              borderRadius: '10px',
               '& .MuiMenuItem-root': {
                 fontFamily: 'Montserrat',
                 '&:hover': {
                   bgcolor: 'purple.16',
                 },
               },
+            },
+          },
+          PaperProps: {
+            sx: {
+              borderRadius: '10px',
             },
           },
         }}

--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -258,6 +258,25 @@ theme = createTheme(theme, {
         },
       },
     },
+    MuiMenu: {
+      defaultProps: {
+        PaperProps: {
+          sx: { borderRadius: '10px' }, // For some reason this does not work in styleOverrides
+        },
+      },
+      styleOverrides: {
+        list: {
+          '& .MuiMenuItem-root': {
+            '&:hover': {
+              backgroundColor: theme.palette.purple[16],
+            },
+          },
+        },
+        paper: {
+          marginTop: '4px',
+        },
+      },
+    },
   },
 })
 

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -18,11 +18,14 @@ import {
   Box,
   Button,
   Grid,
+  Menu,
+  MenuItem,
   SvgIcon,
   SvgIconProps,
   Typography,
 } from '@mui/material'
 import { ReactComponent as Lsc } from '@assets/img/lscicon.svg'
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material'
 
 const LscIcon = (props: SvgIconProps) => {
   return <SvgIcon inheritViewBox component={Lsc} {...props} />
@@ -235,6 +238,16 @@ export const EditZing = () => {
     selectedGroupNumbers.includes(group.groupNumber)
   )
 
+  // Open and close the 'Send email to' menu drop down
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const menuOpen = Boolean(anchorEl)
+  const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleMenuClose = () => {
+    setAnchorEl(null)
+  }
+
   return courseInfo && hasLoadedStudentData ? (
     <Box>
       <MatchLoading
@@ -262,11 +275,33 @@ export const EditZing = () => {
           {courseInfo.names.join(', ')}
         </Typography>
         <Box flexGrow={2} />
-        <Button>
-          {selectedGroupNumbers.length === 0
-            ? 'Send Email To'
-            : 'Email Selected'}
-        </Button>
+        {selectedGroupNumbers.length === 0 ? (
+          <>
+            <Button
+              onClick={handleMenuOpen}
+              endIcon={menuOpen ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+            >
+              Send email to
+            </Button>
+            <Menu
+              anchorEl={anchorEl}
+              open={menuOpen}
+              onClose={handleMenuClose}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'right',
+              }}
+              transformOrigin={{
+                vertical: 'top',
+                horizontal: 'right',
+              }}
+            >
+              <MenuItem>Newly Matched</MenuItem>
+            </Menu>
+          </>
+        ) : (
+          <Button>Email Selected</Button>
+        )}
       </Box>
 
       <Box m={6}>

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -248,6 +248,15 @@ export const EditZing = () => {
     setAnchorEl(null)
   }
 
+  const handleSelectNewlyMatched = () => {
+    setSelectedGroupNumbers(
+      studentGroups
+        .filter((group) => group.shareMatchEmailTimestamp === null)
+        .map((group) => group.groupNumber)
+    )
+    handleMenuClose()
+  }
+
   return courseInfo && hasLoadedStudentData ? (
     <Box>
       <MatchLoading
@@ -296,11 +305,15 @@ export const EditZing = () => {
                 horizontal: 'right',
               }}
             >
-              <MenuItem>Newly Matched</MenuItem>
+              <MenuItem onClick={handleSelectNewlyMatched}>
+                Newly Matched
+              </MenuItem>
             </Menu>
           </>
         ) : (
-          <Button>Email Selected</Button>
+          <Button onClick={() => console.log('Open emailing modal')}>
+            Email selected
+          </Button>
         )}
       </Box>
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the menu drop down that says "Send email to" and "Email selected" on the edit page. At the moment there is only one option that says "Newly Matched". For now, the onClick of the "Email selected" only logs a message to the console. After #52 is merged in, the diff should be clearer.

- [x] implemented menu drop down send email to
- [x] updated Menu styling theme

### Test Plan <!-- Required -->

https://user-images.githubusercontent.com/22627336/170385809-d0e96514-f793-4529-b344-178deed605a9.mov
