### PR TITLE
Email timestamps backend

### DIFF
--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -11,12 +11,12 @@ type timestampsType = { [key: string]: string }
 
 const timestamps: timestampsType = {
   'Share matched results': 'shareMatchEmailTimestamp',
-  'First no match notification': 'checkInEmailTimestamp',
-  'Second no match notification': 'firstNoMatchEmailTimestamp',
-  'Request to add student to group': 'secondNoMatchEmailTimestamp',
-  'Request to add student to group (late)': 'addStudentEmailTimestamp',
-  'Ask to join group': 'lateAddStudentEmailTimestamp',
-  'Check in with groups': 'askJoinGroupEmailTimestamp',
+  'First no match notification': 'firstNoMatchEmailTimestamp',
+  'Second no match notification': 'secondNoMatchEmailTimestamp',
+  'Request to add student to group': 'addStudentEmailTimestamp',
+  'Request to add student to group (late)': 'lateAddStudentEmailTimestamp',
+  'Ask to join group': 'askJoinGroupEmailTimestamp',
+  'Check in with groups': 'checkInEmailTimestamp',
 }
 
 const getTimestampField = (template: string) => {
@@ -29,7 +29,7 @@ const getTimestampField = (template: string) => {
  * @param template is the name of the template of the email being sent. Matched emailTemplates.js names made by sean. Currently is the string value, may change to the variable value in future (less wordy).
  * @result updates database to have email sent timestamp to current time.
  *  */
-export const updateEmailTimestamp = async (
+export const updateEmailTimestamp = (
   courseId: string,
   group: string,
   template: string
@@ -37,7 +37,7 @@ export const updateEmailTimestamp = async (
   const time = admin.firestore.FieldValue.serverTimestamp()
   const timestampField = getTimestampField(template)
   // must be string format -> parse here or when calling function
-  await courseRef
+  return courseRef
     .doc(courseId)
     .collection('groups')
     .doc(group)
@@ -134,7 +134,7 @@ export const sendMails = async (
       data: JSON.stringify(message),
     })
     if (response.status === 202) {
-      await updateEmailTimestamp(courseId, group, template)
+      updateEmailTimestamp(courseId, group, template)
     }
     return response.status
   } catch (error) {

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -119,7 +119,7 @@ export const sendMails = async (
   authToken: string,
   courseId: string,
   group: string,
-  template: string
+  template = 'Share matched results'
 ) => {
   const access_token = authToken
   try {

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -5,17 +5,38 @@ import admin from 'firebase-admin'
 import { db } from '../config'
 const courseRef = db.collection('courses')
 
+// ==== Timestamp helper functions
+
+type timestampsType = { [key: string]: string }
+
+const timestamps: timestampsType = {
+  'Share matched results': 'shareMatchEmailTimestamp',
+  'First no match notification': 'checkInEmailTimestamp',
+  'Second no match notification': 'firstNoMatchEmailTimestamp',
+  'Request to add student to group': 'secondNoMatchEmailTimestamp',
+  'Request to add student to group (late)': 'addStudentEmailTimestamp',
+  'Ask to join group': 'lateAddStudentEmailTimestamp',
+  'Check in with groups': 'askJoinGroupEmailTimestamp',
+}
+
+const getTimestampField = (template: string) => {
+  return timestamps[template]
+}
+
 /** Updating Email Sent Timestap: 
  * @param courseId is the string courseId usually in the form of a six-digit number such as 358546. 
  * @param groups is the groups for the given course that emails were sent to. 
       Currently type-checked as a string [] but may be a number [] depending on how the frontend obtains group number. 
+ * @param template is the name of the template of the email being sent. Matched emailTemplates.js names made by sean. Currently is the string value, may change to the variable value in future (less wordy). 
  * @result updates database to have email sent timestamp to current time. 
  *  */
 export const updateEmailTimestamp = async (
   courseId: string,
-  groups: string[]
+  groups: string[],
+  template: string
 ) => {
   const time = admin.firestore.FieldValue.serverTimestamp()
+  const timestampField = getTimestampField(template)
 
   // either groups = [0, 1, 2] or ["0", "1", "2"]
   // must be string format -> parse here or when calling function
@@ -25,7 +46,7 @@ export const updateEmailTimestamp = async (
         .doc(courseId)
         .collection('groups')
         .doc(group)
-        .update({ shareMatchEmailTimestamp: time })
+        .update({ [timestampField]: time })
     }),
   ])
 }

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -134,7 +134,7 @@ export const sendMails = async (
       data: JSON.stringify(message),
     })
     if (response.status === 202) {
-      updateEmailTimestamp(courseId, group, template)
+      await updateEmailTimestamp(courseId, group, template)
     }
     return response.status
   } catch (error) {

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -15,19 +15,31 @@ const router = express()
       @param emailSubject
       @param emailRcpts (student email string list )
 
+      @param couseId 6-digit course id
+      @param group group number 
+      @param template string name
+
     @yields: 
       SUCC -> res.data = 'Email send success.' 
       FAIL -> res.data = 'Email send failure.' 
 
     */
 router.post('/send', (req, res) => {
-  const { emailAddress, authToken, emailBody, emailSubject, emailRcpts } =
-    req.body
+  const {
+    emailAddress,
+    authToken,
+    emailBody,
+    emailSubject,
+    emailRcpts,
+    courseId,
+    group,
+    template,
+  } = req.body
 
   const message = createEmailAsJson(emailRcpts, emailSubject, emailBody)
   // console.log(JSON.stringify(message, null, '  '))
 
-  sendMails(emailAddress, message, authToken)
+  sendMails(emailAddress, message, authToken, courseId, group, template)
     .then((result) => {
       if (result === 202) {
         logger.info(

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -52,12 +52,13 @@ router.post('/send', (req, res) => {
  *
  * @param courseId = string of 6-digit course code
  * @param groups = string [] of groups to be sent emails
+ * @param template = is the name of the template of the email being sent. Matched emailTemplates.js names made by sean. Currently is the string value, may change to the variable value in future (less wordy).
  *
  * @yeilds email sent timestamp update in database
  */
 router.post('/timestamp', (req, res) => {
-  const { courseId, groups } = req.body
-  updateEmailTimestamp(courseId, groups)
+  const { courseId, groups, template } = req.body
+  updateEmailTimestamp(courseId, groups, template)
     .then(() => {
       logger.info(
         `Email time updated for groups ${groups.toString()} in course ${courseId}.`

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -49,10 +49,22 @@ router.post('/send', (req, res) => {
     )
 })
 
-router.post('/time', (req, res) => {
+// api root/email/timestamp
+router.post('/timestamp', (req, res) => {
   const { courseId, groups } = req.body
   updateEmailTimestamp(courseId, groups)
-  res.status(200).json('Email Time updated')
+    .then(() => {
+      logger.info(
+        `Email time updated for groups ${groups.toString()} in course ${courseId}.`
+      )
+      res.status(200).json('Email Time updated')
+    })
+    .catch(() => {
+      logger.warn(
+        `Email time failed to update for groups ${groups.toString()} in course ${courseId}.`
+      )
+      res.status(400).json('ERROR: email Time update failure')
+    })
 })
 
 export default router

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { logger } from 'firebase-functions'
-import { createEmailAsJson, sendMails } from './functions'
+import { createEmailAsJson, sendMails, updateEmailTimestamp } from './functions'
 
 const router = express()
 
@@ -47,6 +47,12 @@ router.post('/send', (req, res) => {
         `Email send request failed from ${emailAddress} to ${emailRcpts.toString()}`
       )
     )
+})
+
+router.post('/time', (req, res) => {
+  const { courseId, groups } = req.body
+  updateEmailTimestamp(courseId, groups)
+  res.status(200).json('Email Time updated')
 })
 
 export default router

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -4,19 +4,18 @@ import { createEmailAsJson, sendMails, updateEmailTimestamp } from './functions'
 
 const router = express()
 
-/* 
+/**
 
-    /send endpoint in our backend server. 
+    @.com/email/send endpoint in our backend server. 
 
     POST Req.body needs: 
+      @param emailAddress (admin/user email)
+      @param authToken (must match admin email account)
+      @param emailBody 
+      @param emailSubject
+      @param emailRcpts (student email string list )
 
-      - emailAddress (admin/user email)
-      - authToken (must match admin email account)
-      - emailBody 
-      - emailSubject
-      - emailRcpts (student email string list )
-
-    Returns: 
+    @yields: 
       SUCC -> res.data = 'Email send success.' 
       FAIL -> res.data = 'Email send failure.' 
 
@@ -49,7 +48,13 @@ router.post('/send', (req, res) => {
     )
 })
 
-// api root/email/timestamp
+/** @.com/api root/email/timestamp
+ *
+ * @param courseId = string of 6-digit course code
+ * @param groups = string [] of groups to be sent emails
+ *
+ * @yeilds email sent timestamp update in database
+ */
 router.post('/timestamp', (req, res) => {
   const { courseId, groups } = req.body
   updateEmailTimestamp(courseId, groups)

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -19,7 +19,7 @@ const router = express()
       @param group group number 
       @param template string name
 
-    @yields: 
+    @returns: 
       SUCC -> res.data = 'Email send success.' 
       FAIL -> res.data = 'Email send failure.' 
 


### PR DESCRIPTION
### Summary 

This PR implements the backend functionality of updating the firebase database with the time when the email was sent for each group. 

Updates the backend endpoint to send email to also update the timestamp field when the email is sent successfully. 

This pull request is the first step toward implementing setting the email sent timestamp. 

- [x] backend route and function
- [ ] front-end hitting the backend route #63 

# *New* Test Plan 

1. Submit student surveys 
2. Goto dashboard and match students. 

3. Hit the endpoint to send emails. Now requires more parameters (must input course Id, group number, and template name)
![image](https://user-images.githubusercontent.com/46132945/172720670-50c903ab-6df9-4d4f-98e7-68f8779449fd.png)

5. Goto localhost:4000 (or emulator site) and check that the `shareMatchEmailTimestamp` field is updated to the correct time. 

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/46132945/172035517-2380b5c3-3dca-45d0-8584-3b7a84fb0a16.png">

Alt: 
Pass in other templates results in different timestamp fields/values. 
![image](https://user-images.githubusercontent.com/46132945/172721046-fc2ae9db-ad54-4c91-a31c-1c3c3e773740.png)

6. Purple circle on hover next to group once timestamp is updated: 
![image](https://user-images.githubusercontent.com/46132945/172734085-fe661048-2aed-4c1f-8b44-bca68dfcd67e.png)



### Notes and TODOs
Currently acceptable "template names". These are the same as the template name enum sean implemented, so theoretically shouldn't result in any errors. 
![image](https://user-images.githubusercontent.com/46132945/172720876-761d48fc-cfbe-463f-9aaa-fae69d11ea84.png)


## Breaking changes 
send email endpoint requires more parameters. must update for #63 