### PR TITLE
Catch Class Roster API 404 Errors

### DIFF
--- a/backend/functions/src/course/get_course_id.ts
+++ b/backend/functions/src/course/get_course_id.ts
@@ -22,7 +22,15 @@ async function getCourseId(
   }
 
   const url = constructUrl(courseCatalogName, roster)
-  const response = await axios.get(url)
+  const response = await axios.get(url).catch((error) => {
+    if (error.response.status === 404) {
+      throw new Error(
+        `Could not find course ${courseCatalogName} in roster ${roster}`
+      )
+    } else {
+      throw error
+    }
+  })
 
   //first .data just gets the response data from the request, while the second
   // .data gets the "data" field in the API response.
@@ -33,7 +41,9 @@ async function getCourseId(
   )
 
   if (!classData) {
-    throw new Error(`Could not find course data for class ${courseCatalogName}`)
+    throw new Error(
+      `Could not find course ${courseCatalogName} in roster ${roster}`
+    )
   }
 
   return classData.crseId.toString()

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -39,7 +39,7 @@ const addStudentSurveyResponse = async (
   const courseIdsWithName = await Promise.all(
     courseCatalogNames.map(async (name) => ({
       catalogName: name,
-      courseId: await mapCatalogNameToCourseId(name, 'SU22'),
+      courseId: await mapCatalogNameToCourseId(name, 'SU22'), // May throw error
     }))
   )
 

--- a/backend/functions/src/student/routes.ts
+++ b/backend/functions/src/student/routes.ts
@@ -23,7 +23,6 @@ router.post('/survey', (req, res) => {
       if (err.name === 'processing_err') {
         return res.status(500).send({ success: false, message: err.message })
       }
-      console.log(err)
       return res.status(400).send({ success: false, message: err.message })
     })
 })


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request provides better error messages for the student survey when invalid courses are submitted. Previously, we only returned a custom error message when the class could not be found in a successfully returned array of classes. Now a custom error message is returned when Class Roster can't even find the subject or course levels.

- [x] better survey error messages by catching 404 errors

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Tested classes such as ABC 1100, CS 8000, CS 1111, CS 3110, and CS 31110 for SU22
- ABC 1100 - subject does not exist
- CS 8000 - course level does not exist
- CS 1111 and CS 3110 - classes are not offered in SU22 (or don't exist)
- CS 31110 and cs 3110 - improper class format

### Notes

Only catching 404 errors because they are expected behavior. Other errors will be passed through and logged to the Cloud Functions console.