### PR TITLE
Displaying other email timestamps 

### DIFF
--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -60,6 +60,12 @@ async function getStudentsForCourse(courseId: any) {
     shareMatchEmailTimestamp: data[index].shareMatchEmailTimestamp
       ? data[index].shareMatchEmailTimestamp.toDate()
       : null,
+    checkInEmailTimestamp: data[index].checkInEmailTimestamp
+      ? data[index].checkInEmailTimestamp.toDate()
+      : null,
+    addStudentEmailTimestamp: data[index].addStudentEmailTimestamp
+      ? data[index].addStudentEmailTimestamp.toDate()
+      : null,
   }))
 
   return {

--- a/backend/functions/src/matching/functions.ts
+++ b/backend/functions/src/matching/functions.ts
@@ -121,7 +121,7 @@ async function makeMatches(courseId: string) {
       updateTime: new Date(),
       shareMatchEmailTimestamp: null,
       checkInEmailTimestamp: null,
-      addStudentEmailTimestamp: null, // timestamp for option of "share matching results"
+      addStudentEmailTimestamp: null,
     })
   }
   for (let i = 0; i < studentDataDoubles.length; i += 2) {
@@ -134,7 +134,7 @@ async function makeMatches(courseId: string) {
       updateTime: new Date(),
       shareMatchEmailTimestamp: null,
       checkInEmailTimestamp: null,
-      addStudentEmailTimestamp: null, // timestamp for option of "share matching results"
+      addStudentEmailTimestamp: null,
     })
   }
 

--- a/backend/functions/src/matching/functions.ts
+++ b/backend/functions/src/matching/functions.ts
@@ -119,7 +119,9 @@ async function makeMatches(courseId: string) {
       memberData: newGroup,
       createTime: new Date(),
       updateTime: new Date(),
-      shareMatchEmailTimestamp: null, // timestamp for option of "share matching results"
+      shareMatchEmailTimestamp: null,
+      checkInEmailTimestamp: null,
+      addStudentEmailTimestamp: null, // timestamp for option of "share matching results"
     })
   }
   for (let i = 0; i < studentDataDoubles.length; i += 2) {
@@ -130,7 +132,9 @@ async function makeMatches(courseId: string) {
       memberData: newGroup,
       createTime: new Date(),
       updateTime: new Date(),
-      shareMatchEmailTimestamp: null, // timestamp for option of "share matching results"
+      shareMatchEmailTimestamp: null,
+      checkInEmailTimestamp: null,
+      addStudentEmailTimestamp: null, // timestamp for option of "share matching results"
     })
   }
 
@@ -141,6 +145,8 @@ async function makeMatches(courseId: string) {
     createTime: admin.firestore.FieldValue.serverTimestamp(),
     updateTime: admin.firestore.FieldValue.serverTimestamp(),
     shareMatchEmailTimestamp: group.shareMatchEmailTimestamp,
+    checkInEmailTimestamp: group.checkInEmailTimestamp,
+    addStudentEmailTimestamp: group.addStudentEmailTimestamp,
   }))
 
   // lastly, update the collections to reflect this matching

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -268,6 +268,7 @@ export const EditZing = () => {
       .catch((error) => displayNetworkError(error.message))
   }
 
+  /** Handles updating the groups state when we send an email so timestamp shows directly after email is sent without requiring page refresh. */
   const handleEmailTimestamp = () => {
     axios
       .get(`${API_ROOT}${COURSE_API}/students/${courseId}`)

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -268,6 +268,40 @@ export const EditZing = () => {
       .catch((error) => displayNetworkError(error.message))
   }
 
+  const handleEmailTimestamp = () => {
+    axios
+      .get(`${API_ROOT}${COURSE_API}/students/${courseId}`)
+      .then((res: AxiosResponse<CourseStudentDataResponse>) => {
+        setUnmatchedStudents(
+          res.data.data.unmatched.map((student) => ({
+            ...student,
+            submissionTime: new Date(student.submissionTime),
+          }))
+        )
+        setStudentGroups(
+          res.data.data.groups.map((group) => ({
+            ...group,
+            memberData: group.memberData.map((student) => ({
+              ...student,
+              submissionTime: new Date(student.submissionTime),
+            })),
+            createTime: new Date(group.createTime),
+            updateTime: new Date(group.updateTime),
+            shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
+              ? new Date(group.shareMatchEmailTimestamp)
+              : null,
+            checkInEmailTimestamp: group.checkInEmailTimestamp
+              ? new Date(group.checkInEmailTimestamp)
+              : null,
+            addStudentEmailTimestamp: group.addStudentEmailTimestamp
+              ? new Date(group.addStudentEmailTimestamp)
+              : null,
+          }))
+        )
+      })
+      .catch((error) => displayNetworkError(error.message))
+  }
+
   // TODO: remove this eslint disable once selectedGroups is used
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const selectedGroups = studentGroups.filter((group) =>
@@ -303,6 +337,7 @@ export const EditZing = () => {
           setEmailSent={setEmailSent}
           setEmailSentError={setEmailSentError}
           courseNames={courseInfo.names}
+          handleEmailTimestamp={handleEmailTimestamp}
         />
       )}
       <MatchLoading

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -112,6 +112,12 @@ export const EditZing = () => {
             shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
               ? new Date(group.shareMatchEmailTimestamp)
               : null,
+            checkInEmailTimestamp: group.checkInEmailTimestamp
+              ? new Date(group.checkInEmailTimestamp)
+              : null,
+            addStudentEmailTimestamp: group.addStudentEmailTimestamp
+              ? new Date(group.addStudentEmailTimestamp)
+              : null,
           }))
         )
         setHasLoadedStudentData(true)
@@ -248,6 +254,12 @@ export const EditZing = () => {
             shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
               ? new Date(group.shareMatchEmailTimestamp)
               : null,
+            checkInEmailTimestamp: group.checkInEmailTimestamp
+              ? new Date(group.checkInEmailTimestamp)
+              : null,
+            addStudentEmailTimestamp: group.addStudentEmailTimestamp
+              ? new Date(group.addStudentEmailTimestamp)
+              : null,
           }))
         )
         setStudentGroups(groups)
@@ -365,6 +377,8 @@ export const EditZing = () => {
                 studentList={studentGroup.memberData}
                 groupNumber={studentGroup.groupNumber}
                 shareMatchEmailTimestamp={studentGroup.shareMatchEmailTimestamp}
+                checkInEmailTimestamp={studentGroup.checkInEmailTimestamp}
+                addStudentEmailTimestamp={studentGroup.addStudentEmailTimestamp}
                 moveStudent={moveStudent}
                 createTime={studentGroup.createTime}
                 updateTime={studentGroup.updateTime}

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -20,6 +20,7 @@ export const EmailModal = ({
   courseNames,
   setEmailSent,
   setEmailSentError,
+  handleEmailTimestamp,
 }: EmailModalProps) => {
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateName>(
     '' as TemplateName
@@ -92,6 +93,7 @@ export const EmailModal = ({
       } else {
         setEmailSent(true)
         setIsEmailing(false)
+        handleEmailTimestamp()
       }
     } catch (e) {
       console.log(`error was ${e}`)

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -16,7 +16,7 @@ const ShareMatchEmailToolTip = ({
 }) => {
   return (
     <Tooltip
-      title={`Share matching results: Sent on ${month}/${day}`}
+      title={`Shared matching results: ${month}/${day}`}
       placement="bottom-start"
       componentsProps={{
         tooltip: {
@@ -43,7 +43,7 @@ const CheckInEmailToolTip = ({
 }) => {
   return (
     <Tooltip
-      title={`Check In Email: Sent on ${month}/${day}`}
+      title={`Checked In: ${month}/${day}`}
       placement="bottom-start"
       componentsProps={{
         tooltip: {
@@ -70,7 +70,7 @@ const AddStudentEmailToolTip = ({
 }) => {
   return (
     <Tooltip
-      title={`Request to Add Student Email: Sent on ${month}/${day}`}
+      title={`Requested to Add Student: ${month}/${day}`}
       placement="bottom-start"
       componentsProps={{
         tooltip: {

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -7,87 +7,6 @@ import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
 import { Box, Tooltip, Grid, Checkbox } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 
-const ShareMatchEmailToolTip = ({
-  month,
-  day,
-}: {
-  month: number
-  day: number
-}) => {
-  return (
-    <Tooltip
-      title={`Shared matching results: ${month}/${day}`}
-      placement="bottom-start"
-      componentsProps={{
-        tooltip: {
-          sx: {
-            bgcolor: 'essentials.main',
-            color: 'white',
-            fontWeight: 600,
-            borderRadius: '10px',
-          },
-        },
-      }}
-    >
-      <CircleIcon sx={{ fontSize: 10 }} color="primary" />
-    </Tooltip>
-  )
-}
-
-const CheckInEmailToolTip = ({
-  month,
-  day,
-}: {
-  month: number
-  day: number
-}) => {
-  return (
-    <Tooltip
-      title={`Checked In: ${month}/${day}`}
-      placement="bottom-start"
-      componentsProps={{
-        tooltip: {
-          sx: {
-            bgcolor: 'essentials.main',
-            color: 'white',
-            fontWeight: 600,
-            borderRadius: '10px',
-          },
-        },
-      }}
-    >
-      <CircleIcon sx={{ fontSize: 10 }} color="primary" />
-    </Tooltip>
-  )
-}
-
-const AddStudentEmailToolTip = ({
-  month,
-  day,
-}: {
-  month: number
-  day: number
-}) => {
-  return (
-    <Tooltip
-      title={`Requested to Add Student: ${month}/${day}`}
-      placement="bottom-start"
-      componentsProps={{
-        tooltip: {
-          sx: {
-            bgcolor: 'essentials.main',
-            color: 'white',
-            fontWeight: 600,
-            borderRadius: '10px',
-          },
-        },
-      }}
-    >
-      <CircleIcon sx={{ fontSize: 10 }} color="primary" />
-    </Tooltip>
-  )
-}
-
 /** the equivalent of Column */
 export const GroupGrid = ({
   studentList,
@@ -101,6 +20,21 @@ export const GroupGrid = ({
   selected,
   handleChecked,
 }: GroupGridProps) => {
+  const tooltips = [
+    {
+      type: shareMatchEmailTimestamp,
+      text: 'Shared match results: ',
+    },
+    {
+      type: checkInEmailTimestamp,
+      text: 'Checked in: ',
+    },
+    {
+      type: addStudentEmailTimestamp,
+      text: 'Requested student add: ',
+    },
+  ]
+
   const [{ isOver }, drop] = useDrop({
     accept: STUDENT_TYPE,
     drop: (item: DnDStudentTransferType) => {
@@ -152,24 +86,32 @@ export const GroupGrid = ({
           >
             <StyledGroupText>{`Group ${groupNumber}`}</StyledGroupText>
           </Tooltip>
-          {shareMatchEmailTimestamp && (
-            <ShareMatchEmailToolTip
-              month={shareMatchEmailTimestamp.getMonth() + 1}
-              day={shareMatchEmailTimestamp.getDate()}
-            />
-          )}
-          {checkInEmailTimestamp && (
-            <CheckInEmailToolTip
-              month={checkInEmailTimestamp.getMonth() + 1}
-              day={checkInEmailTimestamp.getDate()}
-            />
-          )}
-          {addStudentEmailTimestamp && (
-            <AddStudentEmailToolTip
-              month={addStudentEmailTimestamp.getMonth() + 1}
-              day={addStudentEmailTimestamp.getDate()}
-            />
-          )}
+          {tooltips.map((timestamp, index) => {
+            if (timestamp.type) {
+              const month = timestamp.type.getMonth() + 1
+              const day = timestamp.type.getDate()
+              return (
+                <Tooltip
+                  key={index}
+                  title={`${timestamp.text + month}/${day}`}
+                  placement="bottom-start"
+                  componentsProps={{
+                    tooltip: {
+                      sx: {
+                        bgcolor: 'essentials.main',
+                        color: 'white',
+                        fontWeight: 600,
+                        borderRadius: '10px',
+                      },
+                    },
+                  }}
+                >
+                  <CircleIcon sx={{ fontSize: 10 }} color="primary" />
+                </Tooltip>
+              )
+            }
+            return null
+          })}
           <Box flexGrow={2} />
           <Checkbox
             color="secondary"

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -34,6 +34,60 @@ const ShareMatchEmailToolTip = ({
   )
 }
 
+const CheckInEmailToolTip = ({
+  month,
+  day,
+}: {
+  month: number
+  day: number
+}) => {
+  return (
+    <Tooltip
+      title={`Check In Email: Sent on ${month}/${day}`}
+      placement="bottom-start"
+      componentsProps={{
+        tooltip: {
+          sx: {
+            bgcolor: 'essentials.main',
+            color: 'white',
+            fontWeight: 600,
+            borderRadius: '10px',
+          },
+        },
+      }}
+    >
+      <CircleIcon sx={{ fontSize: 10 }} color="primary" />
+    </Tooltip>
+  )
+}
+
+const AddStudentEmailToolTip = ({
+  month,
+  day,
+}: {
+  month: number
+  day: number
+}) => {
+  return (
+    <Tooltip
+      title={`Request to Add Student Email: Sent on ${month}/${day}`}
+      placement="bottom-start"
+      componentsProps={{
+        tooltip: {
+          sx: {
+            bgcolor: 'essentials.main',
+            color: 'white',
+            fontWeight: 600,
+            borderRadius: '10px',
+          },
+        },
+      }}
+    >
+      <CircleIcon sx={{ fontSize: 10 }} color="primary" />
+    </Tooltip>
+  )
+}
+
 /** the equivalent of Column */
 export const GroupGrid = ({
   studentList,
@@ -42,6 +96,8 @@ export const GroupGrid = ({
   createTime,
   updateTime,
   shareMatchEmailTimestamp,
+  checkInEmailTimestamp,
+  addStudentEmailTimestamp,
   selected,
   handleChecked,
 }: GroupGridProps) => {
@@ -100,6 +156,18 @@ export const GroupGrid = ({
             <ShareMatchEmailToolTip
               month={shareMatchEmailTimestamp.getMonth() + 1}
               day={shareMatchEmailTimestamp.getDate()}
+            />
+          )}
+          {checkInEmailTimestamp && (
+            <CheckInEmailToolTip
+              month={checkInEmailTimestamp.getMonth() + 1}
+              day={checkInEmailTimestamp.getDate()}
+            />
+          )}
+          {addStudentEmailTimestamp && (
+            <AddStudentEmailToolTip
+              month={addStudentEmailTimestamp.getMonth() + 1}
+              day={addStudentEmailTimestamp.getDate()}
             />
           )}
           <Box flexGrow={2} />

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -52,6 +52,7 @@ export interface EmailModalProps {
   courseNames: string[]
   setEmailSent: (arg: boolean) => void
   setEmailSentError: (arg: boolean) => void
+  handleEmailTimestamp: () => void
 }
 
 export interface TemplateRadioButtonsProps {

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -17,6 +17,8 @@ export interface GroupGridProps {
   studentList: Student[]
   groupNumber: number
   shareMatchEmailTimestamp: Date | null
+  checkInEmailTimestamp: Date | null
+  addStudentEmailTimestamp: Date | null
   moveStudent: (
     studentToMove: Student,
     fromGroupNumber: number,

--- a/frontend/src/modules/EditZing/Types/CourseInfo.ts
+++ b/frontend/src/modules/EditZing/Types/CourseInfo.ts
@@ -11,6 +11,8 @@ export type Group = {
   createTime: Date
   updateTime: Date
   shareMatchEmailTimestamp: Date | null
+  checkInEmailTimestamp: Date | null
+  addStudentEmailTimestamp: Date | null
 }
 
 export interface CourseInfoResponse {


### PR DESCRIPTION
# Summary 

This PR extends off #43 in that we will also display email sent and tooltips for 2 more templates: Check In and Request to add students. This means that all templates that are able to be selected and sent by staff are now supported. 

### Note for future: 
Not sure if we will/need to display for other/all email types? Currently has 7 templates which would mean 7 dots, which may or may not look funny or be necessary? Well, might be necessary to keep track of all the different emails they send. Not sure. 

This pull request is the first step towards implementing displaying email sent info/timestamps. 

- [x] implemented check in email tooltip
- [x] implemented add student tooltip
- [ ] remaining email templates not implemented 

# Test Plan 
General Flow: 
1. Survey
2. Match 
3. Send an email for each template 
4. Refresh (want to automatically re-render but idk best way on how to since the current state changes we do don't cause re-renders) 
5. Purple dots should appear on next to the group name & number. 
6. Check In tooltip:
<img width="593" alt="Screen Shot 2022-06-11 at 12 04 04 PM" src="https://user-images.githubusercontent.com/46132945/173195582-1e5a1953-9813-4036-9c3d-1d5def8badb6.png">
7. Req add student tooltip: 
<img width="744" alt="image" src="https://user-images.githubusercontent.com/46132945/173195604-471959b0-9ba9-4a2e-a25d-0219e7528919.png">
8. Extra: In database correctly sets timestamps as null initially: 
<img width="564" alt="image" src="https://user-images.githubusercontent.com/46132945/173195685-296d1e31-0260-4136-b7b1-902a7ed154ee.png">


