### PR TITLE
Course ID format: SU22-358546

### DIFF
--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -17,7 +17,7 @@ async function getDataForStudents(emails: string[]) {
   return Promise.all(emails.map((email) => getStudent(email)))
 }
 
-async function getCourseInfo(courseId: any) {
+async function getCourseInfo(courseId: string) {
   const snapshot = await courseRef.doc(courseId).get()
   if (!snapshot.exists) throw new Error("This course doesn't exist")
   const result: any = snapshot.data()
@@ -35,7 +35,7 @@ async function getAllCourses() {
   })
 }
 
-async function getStudentsForCourse(courseId: any) {
+async function getStudentsForCourse(courseId: string) {
   const courseSnapshot = await courseRef.doc(courseId).get()
   if (!courseSnapshot.exists)
     throw new Error(`Course ${courseId} does not exist`)

--- a/backend/functions/src/course/get_course_id.ts
+++ b/backend/functions/src/course/get_course_id.ts
@@ -46,7 +46,7 @@ async function getCourseId(
     )
   }
 
-  return classData.crseId.toString()
+  return `${roster}-${classData.crseId}`
 }
 
 export default getCourseId

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -25,7 +25,7 @@ const getTimestampField = (template: string) => {
 }
 
 /** Updating Email Sent Timestap:
- * @param courseId is the string courseId usually in the form of a six-digit number such as 358546.
+ * @param courseId is the string courseId usually in the form of a roster and six-digit number such as SU22-358546.
  * @param group is the group for the given course that emails were sent to.
  * @param template is the name of the template of the email being sent. Matched emailTemplates.js names made by sean. Currently is the string value, may change to the variable value in future (less wordy).
  * @result updates database to have email sent timestamp to current time.
@@ -102,7 +102,7 @@ export const createEmailAsJson = (
     @param message: graph api request body data
     @param authToken: string that must match the [from] email and 
       logged in user
-    @param courseId: 6-digit course id 
+    @param courseId: roster and 6-digit course id 
     @param group: group number that email is being sent to
     @param template: string of template name
     

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -15,7 +15,7 @@ const router = express()
       @param emailSubject
       @param emailRcpts (student email string list )
 
-      @param couseId 6-digit course id
+      @param courseId roster and 6-digit course id
       @param group group number 
       @param template string name
 

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -35,11 +35,13 @@ const addStudentSurveyResponse = async (
   courseRef = courseR,
   studentRef = studentR
 ) => {
+  const roster = 'SU22' // Summer 2022 for LSC launch
+
   // Find the courseId of all requested courses in survey
   const courseIdsWithName = await Promise.all(
     courseCatalogNames.map(async (name) => ({
       catalogName: name,
-      courseId: await mapCatalogNameToCourseId(name, 'SU22'), // May throw error
+      courseId: await mapCatalogNameToCourseId(name, roster), // May throw error
     }))
   )
 
@@ -157,6 +159,7 @@ const addStudentSurveyResponse = async (
   await Promise.all(allUpdates)
 }
 
+// This has not been used in a very long long time
 async function removeStudent(email: string) {
   const studentDocRef = studentR.doc(email)
   const data = (await studentDocRef.get()).data()

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -107,6 +107,8 @@ const addStudentSurveyResponse = async (
         if (!snapshot.exists) {
           return snapshot.ref
             .set({
+              roster,
+              courseNumber: course.courseId.replace(`${roster}-`, ''),
               unmatched: [],
               names: course.catalogNames,
               lastGroupNumber: 0,

--- a/frontend/src/modules/Dashboard/Types/CourseInfo.ts
+++ b/frontend/src/modules/Dashboard/Types/CourseInfo.ts
@@ -1,4 +1,6 @@
 export interface CourseInfo {
+  roster: string
+  courseNumber: string
   unmatched: string[]
   lastGroupNumber: number
   names: string[]

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -363,7 +363,7 @@ export const EditZing = () => {
       >
         <LscIcon sx={{ height: '50px', width: '50px' }} />
         <Typography variant="h4" component="h1">
-          {courseInfo.names.join(', ')}
+          {courseInfo.names.join(', ')} ({courseInfo.roster})
         </Typography>
         <Box flexGrow={2} />
         {selectedGroupNumbers.length === 0 ? (

--- a/frontend/src/modules/EditZing/Types/CourseInfo.ts
+++ b/frontend/src/modules/EditZing/Types/CourseInfo.ts
@@ -1,6 +1,8 @@
 import { Student } from './Student'
 
+// This interface does not contain all of the fields that are returned
 export interface CourseInfo {
+  roster: string
   names: string[]
   unmatched: string[]
 }

--- a/frontend/src/modules/EditZing/Types/Student.ts
+++ b/frontend/src/modules/EditZing/Types/Student.ts
@@ -1,15 +1,14 @@
 export type Student = {
   name: string
   email: string
-  year: number
+  year: string
   college: string
-  preferredWorkingTime: number
   submissionTime: Date
   groups: GroupMembership[]
 }
 
 export type GroupMembership = {
-  courseId: number
+  courseId: string
   groupNumber: number
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request changes the course ID format to be of the form `SU22-358546`, which includes the roster the course is associated with and the course number. Using only the course number would cause the same class in two different semesters to be blended together in our current database, since the Class Roster API maps CS 2110 in SU22 and FA22 to be 358546.

- [x] changed course IDs to be of the form `SU22-358546`
- [x] minor type fixes
- [x] display roster on edit page

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

The URLs look like this now. Also added the semester to the title.

<img width="1188" alt="Screen Shot 2022-06-12 at 16 52 57" src="https://user-images.githubusercontent.com/22627336/173258915-8d5b6a46-973b-41d0-b0e1-5b5be8500c2d.png">

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

```json
"SU22-358546": {
  "roster": "SU22",
  "courseNumber": "358546",
  "names": ["CS 2110", "ENGRD 2110"],
  "..."
}
```

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
- course ID are different format!
