### PR TITLE
Survey accessibility v1 

### DIFF
--- a/frontend/src/modules/Core/Styles/RadioButton.style.tsx
+++ b/frontend/src/modules/Core/Styles/RadioButton.style.tsx
@@ -11,7 +11,7 @@ const defaultContainerStyle = css`
   cursor: pointer;
 `
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   ${defaultContainerStyle}
   display: flex;
   justify-content: flex-start;

--- a/frontend/src/modules/Core/Styles/RadioButtons.style.tsx
+++ b/frontend/src/modules/Core/Styles/RadioButtons.style.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   display: flex;
   flex-direction: column;
   align-items: left;

--- a/frontend/src/modules/CreateZing/Styles/FormStyle.style.tsx
+++ b/frontend/src/modules/CreateZing/Styles/FormStyle.style.tsx
@@ -34,7 +34,7 @@ export const StyledFullPanelNoPadding = styled.div`
   ${fullPanel}
 `
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   height: 86%;
   width: 80%;
   background-color: ${colors.white};

--- a/frontend/src/modules/Dashboard/Components/GroupCard.tsx
+++ b/frontend/src/modules/Dashboard/Components/GroupCard.tsx
@@ -80,7 +80,7 @@ export const GroupCard = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
           <GroupsIcon />
           <Typography>
-            {groupsFormed}{' '}
+            {groupsFormed}
             {groupsFormed === 1 ? 'Group Formed' : 'Groups Formed'}
           </Typography>
         </Box>

--- a/frontend/src/modules/Dashboard/Styles/Dashboard.style.tsx
+++ b/frontend/src/modules/Dashboard/Styles/Dashboard.style.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { BsChevronDown } from 'react-icons/bs'
 import { colors, h4 } from '@core'
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   height: 100%;
   width: 100%;
   background-color: ${colors.white};

--- a/frontend/src/modules/EditZing/Styles/StudentAndGroup.style.tsx
+++ b/frontend/src/modules/EditZing/Styles/StudentAndGroup.style.tsx
@@ -1,7 +1,7 @@
 import { colors, h3 } from '@core'
 import styled from 'styled-components'
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   height: 100%;
   display: flex;
   justify-content: center;

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
-import { IconButton, Box } from '@mui/material'
+import {
+  IconButton,
+  Box,
+  TextField,
+  InputLabel,
+  FormControl,
+  Input,
+  FormHelperText,
+} from '@mui/material'
 import { ArrowForward } from '@mui/icons-material'
-import { TextField } from '@mui/material'
 import {
   StyledContainer,
   StyledLeftPanel,
@@ -12,6 +19,7 @@ import {
   StyledTitleWrapper,
   StyledHeaderText,
   StyledWelcomeText,
+  StyledErrorText,
 } from 'Survey/Styles/StepBegin.style'
 import { StepBeginProps } from 'Survey/Types'
 
@@ -44,29 +52,42 @@ export const StepBegin = ({
           <StyledHeaderText>Hi,</StyledHeaderText>
           <StyledWelcomeText>Find study partners!</StyledWelcomeText>
         </StyledTitleWrapper>
+
         <StyledFields>
+          <InputLabel htmlFor="user name"> Name: </InputLabel>
           <TextField
-            placeholder="Name"
+            id="user name"
             variant="standard"
+            aria-label="user name"
+            placeholder="Martha E. Pollack"
+            // variant="standard"
             sx={textInputStyle}
             value={name}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               setName(e.target.value)
             }
           />
+          <InputLabel htmlFor="user email"> Email: </InputLabel>
           <TextField
+            id="user email"
+            variant="standard"
+            aria-label="user email"
             value={email}
             sx={textInputStyle}
-            variant="standard"
             type="email"
             onBlur={() => setIsValidEmail(validEmail.test(email))}
-            placeholder="Cornell Email"
+            placeholder="mep22@cornell.edu"
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               setEmail(e.target.value)
             }
             error={!isValidEmail}
-            helperText={isValidEmail ? ' ' : 'Invalid Email'}
           />
+          <FormHelperText id="email-helper-text" sx={{ fontColor: 'red' }}>
+            {' '}
+            <StyledErrorText>
+              {isValidEmail ? ' ' : 'Invalid Email'}
+            </StyledErrorText>
+          </FormHelperText>
         </StyledFields>
         <Box
           sx={{
@@ -81,6 +102,7 @@ export const StepBegin = ({
             onClick={gotoNextStep}
             disabled={name === '' || email === '' || !isValidEmail}
             sx={{ boxShadow: 3 }}
+            aria-label="Next button"
           >
             <ArrowForward />
           </IconButton>

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -7,6 +7,7 @@ import {
   FormControl,
   Input,
   FormHelperText,
+  Typography,
 } from '@mui/material'
 import { ArrowForward } from '@mui/icons-material'
 import {
@@ -21,6 +22,7 @@ import {
   StyledWelcomeText,
   StyledErrorText,
 } from 'Survey/Styles/StepBegin.style'
+import { StyledLabelText } from 'Survey/Styles/Survey.style'
 import { StepBeginProps } from 'Survey/Types'
 
 export const StepBegin = ({
@@ -48,67 +50,75 @@ export const StepBegin = ({
         <StyledTeamPic />
       </StyledLeftPanel>
       <StyledRightPanel>
-        <StyledTitleWrapper>
-          <StyledHeaderText>Hi,</StyledHeaderText>
-          <StyledWelcomeText>Find study partners!</StyledWelcomeText>
-        </StyledTitleWrapper>
+        <main>
+          <StyledTitleWrapper>
+            <StyledHeaderText>Hi,</StyledHeaderText>
+            <StyledWelcomeText>Find study partners!</StyledWelcomeText>
+          </StyledTitleWrapper>
 
-        <StyledFields>
-          <InputLabel htmlFor="user name"> Name: </InputLabel>
-          <TextField
-            id="user name"
-            variant="standard"
-            aria-label="user name"
-            placeholder="Martha E. Pollack"
-            // variant="standard"
-            sx={textInputStyle}
-            value={name}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setName(e.target.value)
-            }
-          />
-          <InputLabel htmlFor="user email"> Email: </InputLabel>
-          <TextField
-            id="user email"
-            variant="standard"
-            aria-label="user email"
-            value={email}
-            sx={textInputStyle}
-            type="email"
-            onBlur={() => setIsValidEmail(validEmail.test(email))}
-            placeholder="mep22@cornell.edu"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setEmail(e.target.value)
-            }
-            error={!isValidEmail}
-          />
-          <FormHelperText id="email-helper-text" sx={{ fontColor: 'red' }}>
-            {' '}
-            <StyledErrorText>
-              {isValidEmail ? ' ' : 'Invalid Email'}
-            </StyledErrorText>
-          </FormHelperText>
-        </StyledFields>
-        <Box
-          sx={{
-            marginLeft: 'auto',
-            textAlign: 'center',
-            color: 'purple.100',
-            weight: 600,
-          }}
-        >
-          <IconButton
-            className="next"
-            onClick={gotoNextStep}
-            disabled={name === '' || email === '' || !isValidEmail}
-            sx={{ boxShadow: 3 }}
-            aria-label="Next button"
+          <StyledFields>
+            <InputLabel htmlFor="user name">
+              {' '}
+              <StyledLabelText> Name: </StyledLabelText>{' '}
+            </InputLabel>
+            <TextField
+              id="user name"
+              variant="standard"
+              aria-label="user name"
+              placeholder="Martha E. Pollack"
+              // variant="standard"
+              sx={textInputStyle}
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setName(e.target.value)
+              }
+            />
+            <InputLabel htmlFor="user email">
+              {' '}
+              <StyledLabelText> Email: </StyledLabelText>{' '}
+            </InputLabel>
+            <TextField
+              id="user email"
+              variant="standard"
+              aria-label="user email"
+              value={email}
+              sx={textInputStyle}
+              type="email"
+              onBlur={() => setIsValidEmail(validEmail.test(email))}
+              placeholder="mep22@cornell.edu"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setEmail(e.target.value)
+              }
+              error={!isValidEmail}
+            />
+            <FormHelperText id="email-helper-text" sx={{ fontColor: 'red' }}>
+              {' '}
+              <StyledErrorText>
+                {isValidEmail ? ' ' : 'Invalid Email'}
+              </StyledErrorText>
+            </FormHelperText>
+          </StyledFields>
+          <Box
+            sx={{
+              marginLeft: 'auto',
+              textAlign: 'center',
+              color: 'purple.100',
+              weight: 600,
+            }}
           >
-            <ArrowForward />
-          </IconButton>
-          <br />
-          Next
-        </Box>
+            <IconButton
+              className="next"
+              onClick={gotoNextStep}
+              disabled={name === '' || email === '' || !isValidEmail}
+              sx={{ boxShadow: 3 }}
+              aria-label="Next button"
+            >
+              <ArrowForward />
+            </IconButton>
+            <br />
+            Next
+          </Box>
+        </main>
       </StyledRightPanel>
     </StyledContainer>
   )

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -5,6 +5,7 @@ import {
   TextField,
   InputLabel,
   FormHelperText,
+  Typography,
 } from '@mui/material'
 import { ArrowForward } from '@mui/icons-material'
 import {
@@ -54,14 +55,13 @@ export const StepBegin = ({
           </StyledTitleWrapper>
 
           <StyledFields>
-            <InputLabel htmlFor="user name">
-              {' '}
-              <StyledLabelText> Name: </StyledLabelText>{' '}
+            <InputLabel id="Name:" htmlFor="user name">
+              <StyledLabelText> Name: </StyledLabelText>
             </InputLabel>
             <TextField
               id="user name"
               variant="standard"
-              aria-label="user name"
+              aria-labelledby="Name:"
               placeholder="Martha E. Pollack"
               // variant="standard"
               sx={textInputStyle}
@@ -70,14 +70,13 @@ export const StepBegin = ({
                 setName(e.target.value)
               }
             />
-            <InputLabel htmlFor="user email">
-              {' '}
-              <StyledLabelText> Email: </StyledLabelText>{' '}
+            <InputLabel id="Email:" htmlFor="user email">
+              <StyledLabelText> Email: </StyledLabelText>
             </InputLabel>
             <TextField
               id="user email"
               variant="standard"
-              aria-label="user email"
+              aria-labelledby="Email:"
               value={email}
               sx={textInputStyle}
               type="email"
@@ -88,8 +87,7 @@ export const StepBegin = ({
               }
               error={!isValidEmail}
             />
-            <FormHelperText id="email-helper-text" sx={{ fontColor: 'red' }}>
-              {' '}
+            <FormHelperText id="email-helper-text">
               <StyledErrorText>
                 {isValidEmail ? ' ' : 'Invalid Email'}
               </StyledErrorText>
@@ -108,12 +106,11 @@ export const StepBegin = ({
               onClick={gotoNextStep}
               disabled={name === '' || email === '' || !isValidEmail}
               sx={{ boxShadow: 3 }}
-              aria-label="Next button"
+              aria-labelledby="Next"
             >
               <ArrowForward />
             </IconButton>
-            <br />
-            Next
+            <Typography id="Next"> Next </Typography>
           </Box>
         </main>
       </StyledRightPanel>

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -4,10 +4,7 @@ import {
   Box,
   TextField,
   InputLabel,
-  FormControl,
-  Input,
   FormHelperText,
-  Typography,
 } from '@mui/material'
 import { ArrowForward } from '@mui/icons-material'
 import {

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -48,71 +48,69 @@ export const StepBegin = ({
         <StyledTeamPic />
       </StyledLeftPanel>
       <StyledRightPanel>
-        <main>
-          <StyledTitleWrapper>
-            <StyledHeaderText>Hi,</StyledHeaderText>
-            <StyledWelcomeText>Find study partners!</StyledWelcomeText>
-          </StyledTitleWrapper>
+        <StyledTitleWrapper>
+          <StyledHeaderText>Hi,</StyledHeaderText>
+          <StyledWelcomeText>Find study partners!</StyledWelcomeText>
+        </StyledTitleWrapper>
 
-          <StyledFields>
-            <InputLabel id="Name:" htmlFor="user name">
-              <StyledLabelText> Name: </StyledLabelText>
-            </InputLabel>
-            <TextField
-              id="user name"
-              variant="standard"
-              aria-labelledby="Name:"
-              placeholder="Martha E. Pollack"
-              // variant="standard"
-              sx={textInputStyle}
-              value={name}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setName(e.target.value)
-              }
-            />
-            <InputLabel id="Email:" htmlFor="user email">
-              <StyledLabelText> Email: </StyledLabelText>
-            </InputLabel>
-            <TextField
-              id="user email"
-              variant="standard"
-              aria-labelledby="Email:"
-              value={email}
-              sx={textInputStyle}
-              type="email"
-              onBlur={() => setIsValidEmail(validEmail.test(email))}
-              placeholder="mep22@cornell.edu"
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setEmail(e.target.value)
-              }
-              error={!isValidEmail}
-            />
-            <FormHelperText id="email-helper-text">
-              <StyledErrorText>
-                {isValidEmail ? ' ' : 'Invalid Email'}
-              </StyledErrorText>
-            </FormHelperText>
-          </StyledFields>
-          <Box
-            sx={{
-              marginLeft: 'auto',
-              textAlign: 'center',
-              color: 'purple.100',
-              weight: 600,
-            }}
+        <StyledFields>
+          <InputLabel id="Name:" htmlFor="user name">
+            <StyledLabelText> Name: </StyledLabelText>
+          </InputLabel>
+          <TextField
+            id="user name"
+            variant="standard"
+            aria-labelledby="Name:"
+            placeholder="Martha E. Pollack"
+            // variant="standard"
+            sx={textInputStyle}
+            value={name}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setName(e.target.value)
+            }
+          />
+          <InputLabel id="Email:" htmlFor="user email">
+            <StyledLabelText> Email: </StyledLabelText>
+          </InputLabel>
+          <TextField
+            id="user email"
+            variant="standard"
+            aria-labelledby="Email:"
+            value={email}
+            sx={textInputStyle}
+            type="email"
+            onBlur={() => setIsValidEmail(validEmail.test(email))}
+            placeholder="mep22@cornell.edu"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setEmail(e.target.value)
+            }
+            error={!isValidEmail}
+          />
+          <FormHelperText id="email-helper-text">
+            <StyledErrorText>
+              {isValidEmail ? ' ' : 'Invalid Email'}
+            </StyledErrorText>
+          </FormHelperText>
+        </StyledFields>
+        <Box
+          sx={{
+            marginLeft: 'auto',
+            textAlign: 'center',
+            color: 'purple.100',
+            weight: 600,
+          }}
+        >
+          <IconButton
+            className="next"
+            onClick={gotoNextStep}
+            disabled={name === '' || email === '' || !isValidEmail}
+            sx={{ boxShadow: 3 }}
+            aria-labelledby="Next"
           >
-            <IconButton
-              className="next"
-              onClick={gotoNextStep}
-              disabled={name === '' || email === '' || !isValidEmail}
-              sx={{ boxShadow: 3 }}
-              aria-labelledby="Next"
-            >
-              <ArrowForward />
-            </IconButton>
-            <Typography id="Next"> Next </Typography>
-          </Box>
-        </main>
+            <ArrowForward />
+          </IconButton>
+          <Typography id="Next"> Next </Typography>
+        </Box>
       </StyledRightPanel>
     </StyledContainer>
   )

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import {
   StyledContainer,
@@ -11,7 +11,7 @@ import { StyledLabelText } from 'Survey/Styles/Survey.style'
 import { InputField } from '@core/Components'
 import { colors } from '@core/Constants'
 import { StepCourseProps } from 'Survey/Types'
-import { InputLabel } from '@mui/material'
+import { InputLabel, TextField } from '@mui/material'
 
 export const StepCourse = ({
   validCourseRe,
@@ -24,19 +24,53 @@ export const StepCourse = ({
     color: colors.darkpurple,
   }
 
+  const textFieldStyle = {
+    input: { color: 'purple.120', fontSize: '24px', fontWeight: '500' },
+    '& .MuiInput-underline:before': { borderBottomColor: 'purple.75' },
+  }
+
+  const [nextCourse, setNextCourse] = useState('')
+
+  const validCourseName = (name: string) => !name || validCourseRe.test(name)
+
+  const helperText = (name: string) =>
+    !validCourseName(name) ? 'Must be of the form ABC 1100' : ''
+
   const cleanInput = (courseName: string) => {
     return courseName.toUpperCase().trim()
   }
-
+  // Update an existing course and auto-capitalize
   const updateCourse = (index: number, newValue: string) => {
+    setCourses(
+      courses.map((course, i) =>
+        index === i ? newValue.toUpperCase() : course
+      )
+    )
+  }
+
+  // Called on blur, update existing course and trim or removes course if empty
+  const finishUpdateCourse = (index: number, newValue: string) => {
     if (newValue) {
       setCourses(
         courses.map((course, i) =>
-          index === i ? cleanInput(newValue) : course
+          index === i ? newValue.toUpperCase().trim() : course
         )
       )
     } else {
       setCourses(courses.filter((_, i) => index !== i))
+    }
+  }
+
+  // Update the next course field and auto-capitalize as typing
+  const updateNextCourse = (newValue: string) => {
+    setNextCourse(newValue.toUpperCase())
+  }
+
+  // Called on blur, add next course if it's not empty and trims
+  const finishNextCourse = (newValue: string) => {
+    if (newValue) {
+      setCourses([...courses, newValue.toUpperCase().trim()])
+      setNextCourse('')
     }
   }
 
@@ -63,32 +97,28 @@ export const StepCourse = ({
 
         <StyledCoursesWrapper>
           {courses.map((course, index) => (
-            <InputField
-              inputStyle={textInputStyle}
+            <TextField
+              inputProps={{ title: `course ${index} name field` }}
               key={String(index)}
               value={course}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                updateCourse(index, e.target.value)
-              }
-              error={
-                !validCourseRe.test(course)
-                  ? 'Must be of the form ABC 1100'
-                  : ''
-              }
+              onChange={(e) => updateCourse(index, e.target.value)}
+              onBlur={(e) => finishUpdateCourse(index, e.target.value)}
+              error={!validCourseName(course)}
+              helperText={helperText(course)}
+              variant="standard"
+              sx={textFieldStyle}
             />
           ))}
-          <InputLabel htmlFor="course name field">
-            <StyledLabelText> Course Name: </StyledLabelText>
-          </InputLabel>
-          <InputField
-            id="course name field"
-            inputStyle={textInputStyle}
-            key={Math.random().toString()}
+          <TextField
+            inputProps={{ title: `course ${courses.length} name field` }}
             placeholder={placeholder}
-            value={''}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              addCourse(e.target.value)
-            }
+            value={nextCourse}
+            onChange={(e) => updateNextCourse(e.target.value)}
+            onBlur={(e) => finishNextCourse(e.target.value)}
+            error={!validCourseName(nextCourse)}
+            helperText={helperText(nextCourse)}
+            variant="standard"
+            sx={textFieldStyle}
           />
         </StyledCoursesWrapper>
       </main>

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -78,7 +78,6 @@ export const StepCourse = ({
             />
           ))}
           <InputLabel htmlFor="course name field">
-            {' '}
             <StyledLabelText> Course Name: </StyledLabelText>
           </InputLabel>
           <InputField

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -6,24 +6,14 @@ import {
   StyledQuestionText,
   StyledWarningText,
 } from 'Survey/Styles/StepCourse.style'
-import { StyledLabelText } from 'Survey/Styles/Survey.style'
-
-import { InputField } from '@core/Components'
-import { colors } from '@core/Constants'
 import { StepCourseProps } from 'Survey/Types'
-import { InputLabel, TextField } from '@mui/material'
+import { TextField } from '@mui/material'
 
 export const StepCourse = ({
   validCourseRe,
   courses,
   setCourses,
 }: StepCourseProps) => {
-  const textInputStyle = {
-    fontSize: '24px',
-    fontWeight: '600',
-    color: colors.darkpurple,
-  }
-
   const textFieldStyle = {
     input: { color: 'purple.120', fontSize: '24px', fontWeight: '500' },
     '& .MuiInput-underline:before': { borderBottomColor: 'purple.75' },
@@ -36,9 +26,6 @@ export const StepCourse = ({
   const helperText = (name: string) =>
     !validCourseName(name) ? 'Must be of the form ABC 1100' : ''
 
-  const cleanInput = (courseName: string) => {
-    return courseName.toUpperCase().trim()
-  }
   // Update an existing course and auto-capitalize
   const updateCourse = (index: number, newValue: string) => {
     setCourses(
@@ -71,12 +58,6 @@ export const StepCourse = ({
     if (newValue) {
       setCourses([...courses, newValue.toUpperCase().trim()])
       setNextCourse('')
-    }
-  }
-
-  const addCourse = (newValue: string) => {
-    if (newValue) {
-      setCourses([...courses, cleanInput(newValue)])
     }
   }
 

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -85,43 +85,41 @@ export const StepCourse = ({
 
   return (
     <StyledContainer>
-      <main>
-        <StyledQuestionText>
-          What course(s) would you like to find study partners for?
-        </StyledQuestionText>
+      <StyledQuestionText>
+        What course(s) would you like to find study partners for?
+      </StyledQuestionText>
 
-        <StyledWarningText>
-          * You do not need to submit the cross-listed version of the same
-          course more than once
-        </StyledWarningText>
+      <StyledWarningText>
+        * You do not need to submit the cross-listed version of the same course
+        more than once
+      </StyledWarningText>
 
-        <StyledCoursesWrapper>
-          {courses.map((course, index) => (
-            <TextField
-              inputProps={{ title: `course ${index} name field` }}
-              key={String(index)}
-              value={course}
-              onChange={(e) => updateCourse(index, e.target.value)}
-              onBlur={(e) => finishUpdateCourse(index, e.target.value)}
-              error={!validCourseName(course)}
-              helperText={helperText(course)}
-              variant="standard"
-              sx={textFieldStyle}
-            />
-          ))}
+      <StyledCoursesWrapper>
+        {courses.map((course, index) => (
           <TextField
-            inputProps={{ title: `course ${courses.length} name field` }}
-            placeholder={placeholder}
-            value={nextCourse}
-            onChange={(e) => updateNextCourse(e.target.value)}
-            onBlur={(e) => finishNextCourse(e.target.value)}
-            error={!validCourseName(nextCourse)}
-            helperText={helperText(nextCourse)}
+            inputProps={{ title: `course ${index} name field` }}
+            key={String(index)}
+            value={course}
+            onChange={(e) => updateCourse(index, e.target.value)}
+            onBlur={(e) => finishUpdateCourse(index, e.target.value)}
+            error={!validCourseName(course)}
+            helperText={helperText(course)}
             variant="standard"
             sx={textFieldStyle}
           />
-        </StyledCoursesWrapper>
-      </main>
+        ))}
+        <TextField
+          inputProps={{ title: `course ${courses.length} name field` }}
+          placeholder={placeholder}
+          value={nextCourse}
+          onChange={(e) => updateNextCourse(e.target.value)}
+          onBlur={(e) => finishNextCourse(e.target.value)}
+          error={!validCourseName(nextCourse)}
+          helperText={helperText(nextCourse)}
+          variant="standard"
+          sx={textFieldStyle}
+        />
+      </StyledCoursesWrapper>
     </StyledContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -19,6 +19,14 @@ export const StepCourse = ({
     '& .MuiInput-underline:before': { borderBottomColor: 'purple.75' },
   }
 
+  const helperTextStyle = {
+    style: {
+      color: '#d41e42',
+      fontSize: '1rem',
+      fontWeight: 600,
+    },
+  }
+
   const [nextCourse, setNextCourse] = useState('')
 
   const validCourseName = (name: string) => !name || validCourseRe.test(name)
@@ -87,6 +95,7 @@ export const StepCourse = ({
             helperText={helperText(course)}
             variant="standard"
             sx={textFieldStyle}
+            FormHelperTextProps={helperTextStyle}
           />
         ))}
         <TextField
@@ -99,6 +108,7 @@ export const StepCourse = ({
           helperText={helperText(nextCourse)}
           variant="standard"
           sx={textFieldStyle}
+          FormHelperTextProps={helperTextStyle}
         />
       </StyledCoursesWrapper>
     </StyledContainer>

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -9,6 +9,7 @@ import {
 import { InputField } from '@core/Components'
 import { colors } from '@core/Constants'
 import { StepCourseProps } from 'Survey/Types'
+import { InputLabel } from '@mui/material'
 
 export const StepCourse = ({
   validCourseRe,
@@ -48,9 +49,11 @@ export const StepCourse = ({
 
   return (
     <StyledContainer>
-      <StyledQuestionText>
-        What course(s) would you like to find study partners for?
-      </StyledQuestionText>
+      <h1>
+        <StyledQuestionText>
+          What course(s) would you like to find study partners for?
+        </StyledQuestionText>
+      </h1>
       <StyledWarningText>
         * You do not need to submit the cross-listed version of the same course
         more than once
@@ -70,7 +73,9 @@ export const StepCourse = ({
             }
           />
         ))}
+        <InputLabel htmlFor="course name field"> Course Name: </InputLabel>
         <InputField
+          id="course name field"
           inputStyle={textInputStyle}
           key={Math.random().toString()}
           placeholder={placeholder}

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -6,6 +6,8 @@ import {
   StyledQuestionText,
   StyledWarningText,
 } from 'Survey/Styles/StepCourse.style'
+import { StyledLabelText } from 'Survey/Styles/Survey.style'
+
 import { InputField } from '@core/Components'
 import { colors } from '@core/Constants'
 import { StepCourseProps } from 'Survey/Types'
@@ -49,42 +51,48 @@ export const StepCourse = ({
 
   return (
     <StyledContainer>
-      <h1>
+      <main>
         <StyledQuestionText>
           What course(s) would you like to find study partners for?
         </StyledQuestionText>
-      </h1>
-      <StyledWarningText>
-        * You do not need to submit the cross-listed version of the same course
-        more than once
-      </StyledWarningText>
 
-      <StyledCoursesWrapper>
-        {courses.map((course, index) => (
+        <StyledWarningText>
+          * You do not need to submit the cross-listed version of the same
+          course more than once
+        </StyledWarningText>
+
+        <StyledCoursesWrapper>
+          {courses.map((course, index) => (
+            <InputField
+              inputStyle={textInputStyle}
+              key={String(index)}
+              value={course}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                updateCourse(index, e.target.value)
+              }
+              error={
+                !validCourseRe.test(course)
+                  ? 'Must be of the form ABC 1100'
+                  : ''
+              }
+            />
+          ))}
+          <InputLabel htmlFor="course name field">
+            {' '}
+            <StyledLabelText> Course Name: </StyledLabelText>
+          </InputLabel>
           <InputField
+            id="course name field"
             inputStyle={textInputStyle}
-            key={String(index)}
-            value={course}
+            key={Math.random().toString()}
+            placeholder={placeholder}
+            value={''}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              updateCourse(index, e.target.value)
-            }
-            error={
-              !validCourseRe.test(course) ? 'Must be of the form ABC 1100' : ''
+              addCourse(e.target.value)
             }
           />
-        ))}
-        <InputLabel htmlFor="course name field"> Course Name: </InputLabel>
-        <InputField
-          id="course name field"
-          inputStyle={textInputStyle}
-          key={Math.random().toString()}
-          placeholder={placeholder}
-          value={''}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            addCourse(e.target.value)
-          }
-        />
-      </StyledCoursesWrapper>
+        </StyledCoursesWrapper>
+      </main>
     </StyledContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import {
   StyledContainer,
   StyledCongratulationsWrapper,

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -23,7 +23,6 @@ export const StepFinal = ({ success, errorMsg }: StepFinalProps) => {
             <StyledCheck src={success ? check : xmark} />
             {success ? (
               <StyledCongratulationsText>
-                {' '}
                 Congratulations on completing the form! You should receive an
                 email with your team members shortly.
               </StyledCongratulationsText>

--- a/frontend/src/modules/Survey/Components/StepRadio.tsx
+++ b/frontend/src/modules/Survey/Components/StepRadio.tsx
@@ -17,34 +17,32 @@ export const StepRadio = ({
 }: StepProps) => {
   return (
     <StyledContainer>
-      <main>
-        <StyledQuestionText>{question.question}</StyledQuestionText>
-        <StyledRadioButtonsWrapper>
-          <StyledContainer>
-            <StyledFieldSet>
-              <legend>
-                {/**
-                 * TODO
-                 * do we want a legend here or no?  */}
-              </legend>
-              {Object.entries(question.answers).map(
-                ([value, fullDescription]) => (
-                  <RadioButton
-                    currentAnswer={currentAnswer}
-                    onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setAnswer(e.target.value)
-                    }
-                    value={value}
-                    label={fullDescription}
-                    name="RadioButtons"
-                    key={value}
-                  />
-                )
-              )}
-            </StyledFieldSet>
-          </StyledContainer>
-        </StyledRadioButtonsWrapper>
-      </main>
+      <StyledQuestionText>{question.question}</StyledQuestionText>
+      <StyledRadioButtonsWrapper>
+        <StyledContainer>
+          <StyledFieldSet>
+            <legend>
+              {/**
+               * TODO
+               * do we want a legend here or no?  */}
+            </legend>
+            {Object.entries(question.answers).map(
+              ([value, fullDescription]) => (
+                <RadioButton
+                  currentAnswer={currentAnswer}
+                  onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setAnswer(e.target.value)
+                  }
+                  value={value}
+                  label={fullDescription}
+                  name="RadioButtons"
+                  key={value}
+                />
+              )
+            )}
+          </StyledFieldSet>
+        </StyledContainer>
+      </StyledRadioButtonsWrapper>
     </StyledContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepRadio.tsx
+++ b/frontend/src/modules/Survey/Components/StepRadio.tsx
@@ -7,6 +7,7 @@ import {
   StyledErrorWrapper,
   StyledErrorIcon,
   StyledErrorText,
+  StyledFieldSet,
 } from 'Survey/Styles/StepRadio.style'
 import { RadioButton } from '@core'
 import { StepProps } from 'Survey/Types/StepProps'
@@ -19,31 +20,42 @@ export const StepRadio = ({
 }: StepProps) => {
   return (
     <StyledContainer>
-      <StyledQuestionText>
-        {question.question}
-      </StyledQuestionText>
-      <StyledRadioButtonsWrapper>
-        {showError ? (
-          <StyledErrorWrapper>
-            <StyledErrorIcon />
-            <StyledErrorText>Please select an item to continue</StyledErrorText>
-          </StyledErrorWrapper>
-        ) : null}
-        <StyledContainer>
-          {Object.entries(question.answers).map(([value, fullDescription]) => (
-            <RadioButton
-              currentAnswer={currentAnswer}
-              onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setAnswer(e.target.value)
-              }
-              value={value}
-              label={fullDescription}
-              name="RadioButtons"
-              key={value}
-            />
-          ))}
-        </StyledContainer>
-      </StyledRadioButtonsWrapper>
+      <main>
+        <StyledQuestionText>{question.question}</StyledQuestionText>
+        <StyledRadioButtonsWrapper>
+          {showError ? (
+            <StyledErrorWrapper>
+              <StyledErrorIcon />
+              <StyledErrorText>
+                Please select an item to continue
+              </StyledErrorText>
+            </StyledErrorWrapper>
+          ) : null}
+          <StyledContainer>
+            <StyledFieldSet>
+              <legend>
+                {/**
+                 * TODO
+                 * do we want a legend here or no?  */}
+              </legend>
+              {Object.entries(question.answers).map(
+                ([value, fullDescription]) => (
+                  <RadioButton
+                    currentAnswer={currentAnswer}
+                    onClick={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setAnswer(e.target.value)
+                    }
+                    value={value}
+                    label={fullDescription}
+                    name="RadioButtons"
+                    key={value}
+                  />
+                )
+              )}
+            </StyledFieldSet>
+          </StyledContainer>
+        </StyledRadioButtonsWrapper>
+      </main>
     </StyledContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepRadio.tsx
+++ b/frontend/src/modules/Survey/Components/StepRadio.tsx
@@ -4,9 +4,6 @@ import {
   StyledContainer,
   StyledQuestionText,
   StyledRadioButtonsWrapper,
-  StyledErrorWrapper,
-  StyledErrorIcon,
-  StyledErrorText,
   StyledFieldSet,
 } from 'Survey/Styles/StepRadio.style'
 import { RadioButton } from '@core'
@@ -23,14 +20,6 @@ export const StepRadio = ({
       <main>
         <StyledQuestionText>{question.question}</StyledQuestionText>
         <StyledRadioButtonsWrapper>
-          {showError ? (
-            <StyledErrorWrapper>
-              <StyledErrorIcon />
-              <StyledErrorText>
-                Please select an item to continue
-              </StyledErrorText>
-            </StyledErrorWrapper>
-          ) : null}
           <StyledContainer>
             <StyledFieldSet>
               <legend>

--- a/frontend/src/modules/Survey/Components/StepRadio.tsx
+++ b/frontend/src/modules/Survey/Components/StepRadio.tsx
@@ -10,7 +10,6 @@ import { RadioButton } from '@core'
 import { StepProps } from 'Survey/Types/StepProps'
 
 export const StepRadio = ({
-  showError,
   currentAnswer,
   setAnswer,
   question,
@@ -21,11 +20,7 @@ export const StepRadio = ({
       <StyledRadioButtonsWrapper>
         <StyledContainer>
           <StyledFieldSet>
-            <legend>
-              {/**
-               * TODO
-               * do we want a legend here or no?  */}
-            </legend>
+            <legend></legend>
             {Object.entries(question.answers).map(
               ([value, fullDescription]) => (
                 <RadioButton

--- a/frontend/src/modules/Survey/Components/StepTemplate.tsx
+++ b/frontend/src/modules/Survey/Components/StepTemplate.tsx
@@ -52,6 +52,7 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
               onClick={handlePrev}
               color="secondary"
               sx={{ boxShadow: 3 }}
+              aria-label="previous button"
             >
               <ArrowBack />
             </IconButton>
@@ -71,6 +72,7 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
               onClick={handleNext}
               disabled={!isStepValid}
               sx={{ boxShadow: 3 }}
+              aria-label="next button"
             >
               {stepNumber === totalSteps ? <Check /> : <ArrowForward />}
             </IconButton>

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -18,6 +18,7 @@ export const Survey = () => {
 
   // If there are custom questions the below will be a network call perhaps
   const questions: Question[] = require('@core/Questions/Questions.json')
+  // import questions from '@core/Questions/Questions.json'
   const numSpecialQuestions = 1 // Course list
   const totalSteps = questions.length + numSpecialQuestions + 1
 

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -94,9 +94,9 @@ export const StyledErrorWrapper = styled.div`
 
 export const StyledErrorText = styled.text`
   ${h4};
-  color: ${colors.red};
+  color: #f52c54;
   padding-left: 0.5rem;
-  font-weight: 700;
+  font-weight: 600;
   position: relative;
 `
 

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -37,13 +37,13 @@ const halfPanel = css`
 export const StyledLeftPanel = styled.div`
   ${halfPanel};
   align-items: center;
-  background: linear-gradient(296.38deg, #6d52af 5.53%, #d9cff2 96.38%);
+  background: #815ed4;
   @media (max-width: 900px) {
     display: none;
   }
 `
 
-export const StyledWhiteActionText = styled.text`
+export const StyledWhiteActionText = styled.h1`
   ${h3};
   color: ${colors.white};
   text-align: center;
@@ -96,7 +96,7 @@ export const StyledErrorText = styled.text`
   ${h4};
   color: ${colors.red};
   padding-left: 0.5rem;
-  font-weight: 500;
+  font-weight: 700;
   position: relative;
 `
 

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -94,7 +94,7 @@ export const StyledErrorWrapper = styled.div`
 
 export const StyledErrorText = styled.text`
   ${h4};
-  color: #f52c54;
+  color: #d41e42;
   padding-left: 0.5rem;
   font-weight: 600;
   position: relative;

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -31,7 +31,6 @@ const panel = css`
 
 const halfPanel = css`
   ${panel};
-  height: 100%;
   width: 50%;
 `
 
@@ -39,6 +38,9 @@ export const StyledLeftPanel = styled.div`
   ${halfPanel};
   align-items: center;
   background: linear-gradient(296.38deg, #6d52af 5.53%, #d9cff2 96.38%);
+  @media (max-width: 900px) {
+    display: none;
+  }
 `
 
 export const StyledWhiteActionText = styled.text`
@@ -53,6 +55,9 @@ export const StyledRightPanel = styled.div`
   ${halfPanel};
   box-sizing: border-box;
   padding: 0 6rem;
+  @media (max-width: 900px) {
+    width: 100%;
+  }
 `
 
 export const StyledFields = styled.div`

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -3,15 +3,8 @@ import styled, { css } from 'styled-components'
 import { colors, h1, h2, h3, h4, StyledComponent } from '@core'
 
 import teamPic from '@assets/img/teamwork.svg'
-import errorIcon from '@assets/img/erroricon.svg'
 
 export { StyledContainer } from 'Survey/Styles/StepTemplate.style'
-
-const ErrorIcon = ({ className }: StyledComponent) => (
-  <div className={className}>
-    <img src={errorIcon} alt="errorIcon" />
-  </div>
-)
 
 const TeamPic = ({ className }: StyledComponent) => (
   <div className={className}>
@@ -81,15 +74,6 @@ export const StyledWelcomeText = styled.text`
   ${h2};
   font-weight: 300;
   color: ${colors.black};
-`
-
-export const StyledErrorIcon = styled(ErrorIcon)`
-  padding-top: 1rem;
-`
-
-export const StyledErrorWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
 `
 
 export const StyledErrorText = styled.text`

--- a/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { h2, h4 } from '@core'
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   margin: auto;
 `
 

--- a/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
@@ -5,7 +5,7 @@ export const StyledContainer = styled.div`
   margin: auto;
 `
 
-export const StyledQuestionText = styled.div`
+export const StyledQuestionText = styled.h1`
   ${h2};
   font-weight: 500;
   line-height: 10px;

--- a/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
@@ -42,6 +42,8 @@ export const StyledCheck = styled(Check)`
 
 export const StyledContainer = styled(Container)`
   background: linear-gradient(296.38deg, #6d52af 5.53%, #d9cff2 96.38%);
+  display: flex;
+  flex-flow: row wrap;
 `
 
 const panel = css`

--- a/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
@@ -41,7 +41,7 @@ export const StyledCheck = styled(Check)`
 `
 
 export const StyledContainer = styled(Container)`
-  background: linear-gradient(296.38deg, #6d52af 5.53%, #d9cff2 96.38%);
+  background: #815ed4;
   display: flex;
   flex-flow: row wrap;
 `
@@ -69,7 +69,7 @@ export const StyledCongratulationsWrapper = styled.div`
   width: 75%;
   margin-top: 10%;
 `
-export const StyledCongratulationsText = styled.text`
+export const StyledCongratulationsText = styled.h1`
   ${h2};
   font-weight: 500;
   color: white;

--- a/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
@@ -1,12 +1,5 @@
 import styled from 'styled-components'
-import errorIcon from '@assets/img/erroricon.svg'
-import { colors, h2, h4, StyledComponent } from '@core'
-
-const ErrorIcon = ({ className }: StyledComponent) => (
-  <div className={className}>
-    <img src={errorIcon} alt="errorIcon" />
-  </div>
-)
+import { h2 } from '@core'
 
 export const StyledContainer = styled.div`
   margin: auto;
@@ -26,23 +19,6 @@ export const StyledQuestionText = styled.h1`
   line-height: 10px;
   text-align: center;
   margin-bottom: 2.5rem;
-`
-
-export const StyledErrorIcon = styled(ErrorIcon)``
-
-export const StyledErrorWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-content: center;
-  margin-bottom: 0.25rem;
-`
-
-export const StyledErrorText = styled.text`
-  ${h4};
-  color: ${colors.red};
-  padding-left: 0.5rem;
-  font-weight: 500;
-  position: relative;
 `
 
 export const StyledFieldSet = styled.fieldset`

--- a/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
@@ -20,7 +20,7 @@ export const StyledRadioButtonsWrapper = styled.div`
   align-items: center;
 `
 
-export const StyledQuestionText = styled.div`
+export const StyledQuestionText = styled.h1`
   ${h2};
   font-weight: 500;
   line-height: 10px;
@@ -43,4 +43,9 @@ export const StyledErrorText = styled.text`
   padding-left: 0.5rem;
   font-weight: 500;
   position: relative;
+`
+
+export const StyledFieldSet = styled.fieldset`
+  border-style: none;
+  border-color: #ffffff;
 `

--- a/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { h2 } from '@core'
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   margin: auto;
 `
 

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -32,7 +32,7 @@ export const StyledFullPanelNoPadding = styled.div`
   ${fullPanel}
 `
 
-export const StyledContainer = styled.div`
+export const StyledContainer = styled.main`
   height: 86.5%;
   width: 80%;
   background-color: ${colors.white};

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -38,7 +38,6 @@ export const StyledContainer = styled.div`
   background-color: ${colors.white};
   box-shadow: -10px -10px 150px rgba(0, 0, 0, 0.1),
     10px 10px 150px rgba(0, 0, 0, 0.1);
-
   display: flex;
 `
 

--- a/frontend/src/modules/Survey/Styles/Survey.style.tsx
+++ b/frontend/src/modules/Survey/Styles/Survey.style.tsx
@@ -1,16 +1,30 @@
 import styled from 'styled-components'
 
-import bg1 from '@assets/img/bg1.svg'
-import bg2 from '@assets/img/bg2.svg'
+import bg from '@assets/img/homebg.svg'
+import bg2 from '@assets/img/blobhomebg2.svg'
 
 export const StyledContainer1 = styled.div`
+  background-image: url(${bg});
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
   height: 100%;
-  background-image: url(${bg1});
-  background-size: cover;
-
   display: flex;
   justify-content: center;
   align-items: center;
+
+  // blob overlay
+  &:before {
+    content: '';
+    background: url(${bg2}) no-repeat bottom;
+    background-size: 100% auto;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 0;
+    object-fit: contain;
 `
 export const StyledContainer2 = styled.div`
   height: 100%;
@@ -20,4 +34,10 @@ export const StyledContainer2 = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+`
+
+export const StyledLabelText = styled.text`
+  padding-left: 0.5rem;
+  font-weight: 700;
+  position: relative;
 `

--- a/frontend/src/modules/Survey/Styles/Survey.style.tsx
+++ b/frontend/src/modules/Survey/Styles/Survey.style.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import bg from '@assets/img/homebg.svg'
 import bg2 from '@assets/img/blobhomebg2.svg'
 
-export const StyledContainer1 = styled.div`
+export const StyledContainer1 = styled.main`
   background-image: url(${bg});
   background-position: center;
   background-repeat: no-repeat;
@@ -25,8 +25,9 @@ export const StyledContainer1 = styled.div`
     left: 0;
     z-index: 0;
     object-fit: contain;
+  }
 `
-export const StyledContainer2 = styled.div`
+export const StyledContainer2 = styled.main`
   height: 100%;
   background-image: url(${bg2});
   background-size: cover;


### PR DESCRIPTION
### Summary

This PR is working towards adding accessibility to the survey. Utilize the WAVE extension to audit our survey screens. Main features added are: 

- [x] aria labels 
- [x] fieldsets 
- [x] input labels
- [x] solidify color 
- [x] make the first step work on mobile/smaller screens 
- [x] h1 heading structure (maybe not necessary) 
- [x] main tag (maybe not necessary) 


This pull request is the first step toward implementing survey accessibility. 



### Test Plan

1. Currently the home page on an iPhone 12 Pro:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/46132945/174249659-a4e0e667-e199-4b3c-ae64-6c14f92e2a25.png">

2. Changed to (removed the left panel completely on smaller screen widths):
![image](https://user-images.githubusercontent.com/46132945/174249781-03fcacd1-d8c9-41e4-b59d-e32aa07e5893.png)

3. Audit on the different steps using WAVE:
![image](https://user-images.githubusercontent.com/46132945/174249878-1d18fe50-d2cb-4534-9cb2-acb7302a5196.png)
![image](https://user-images.githubusercontent.com/46132945/174249919-98b7db11-fa75-4074-9fad-75ce6d90725a.png)
![image](https://user-images.githubusercontent.com/46132945/174249938-7c81436d-17ca-4c4a-8134-f5a2020dcce8.png)
![image](https://user-images.githubusercontent.com/46132945/174249952-c313846c-9cc1-46b0-9be4-ae4ad21d90dd.png)




### Notes 

No real design to work off, just googled form design best practices and implemented how I saw fit. 

ALSO: 
For the courses step, once you put in a course, the text has a failing color contrast. I could make it darker pink? 

AND, I have put the label on the last, most current text field and not the previous ones the user already put in. So that breaks the Input Label audit, but would look messy with labels on each one. 