### PR TITLE
validate emailz

### DIFF
--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -24,7 +24,7 @@ async function removeStudentFromCourse(
   }
 }
 
-const validateEmail = async (email: string) => {
+const validateEmail = (email: string) => {
   const emailRegex = /^\w+@cornell.edu$/
   // if true => valid email. if false => invalid email.
   const validEmail = emailRegex.test(email)
@@ -90,6 +90,16 @@ const addStudentSurveyResponse = async (
     courseId: course.courseId,
     groupNumber: -1,
   }))
+
+  const emailRegex = /^\w+@cornell.edu$/
+  // if true => valid email. if false => invalid email.
+  const validEmail = emailRegex.test(email)
+  console.log(validEmail)
+  if (!validEmail) {
+    const e = new Error('Invalid Email Form')
+    e.name = 'processing_err'
+    throw e
+  }
 
   // First, update the [student] collection to include the data for the new student
   const studentUpdate = studentRef

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -37,6 +37,14 @@ const addStudentSurveyResponse = async (
 ) => {
   const roster = 'SU22' // Summer 2022 for LSC launch
 
+  // 0. Check if email is valid cornell.edu email.
+  const emailRegex = /^\w+@cornell.edu$/
+  // if true => valid email. if false => invalid email.
+  const validEmail = emailRegex.test(email)
+  if (!validEmail) {
+    throw new Error('Invalid Email Form')
+  }
+
   // Find the courseId of all requested courses in survey
   const courseIdsWithName = await Promise.all(
     courseCatalogNames.map(async (name) => ({
@@ -79,16 +87,6 @@ const addStudentSurveyResponse = async (
     courseId: course.courseId,
     groupNumber: -1,
   }))
-
-  // 0. Check if email is valid cornell.edu email.
-  const emailRegex = /^\w+@cornell.edu$/
-  // if true => valid email. if false => invalid email.
-  const validEmail = emailRegex.test(email)
-  if (!validEmail) {
-    const e = new Error('Invalid Email Form')
-    e.name = 'processing_err'
-    throw e
-  }
 
   // First, update the [student] collection to include the data for the new student
   const studentUpdate = studentRef

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -24,17 +24,6 @@ async function removeStudentFromCourse(
   }
 }
 
-const validateEmail = (email: string) => {
-  const emailRegex = /^\w+@cornell.edu$/
-  // if true => valid email. if false => invalid email.
-  const validEmail = emailRegex.test(email)
-  console.log(validEmail)
-  if (validEmail === false) {
-    throw new Error('Invalid Email Form')
-  }
-  return true
-}
-
 // Note: the error handling in this file is done the way it is so it is easier
 // to decide response codes based on error type.
 const addStudentSurveyResponse = async (
@@ -91,10 +80,10 @@ const addStudentSurveyResponse = async (
     groupNumber: -1,
   }))
 
+  // 0. Check if email is valid cornell.edu email.
   const emailRegex = /^\w+@cornell.edu$/
   // if true => valid email. if false => invalid email.
   const validEmail = emailRegex.test(email)
-  console.log(validEmail)
   if (!validEmail) {
     const e = new Error('Invalid Email Form')
     e.name = 'processing_err'
@@ -196,4 +185,4 @@ async function removeStudent(email: string) {
   await Promise.all([courseUpdates, studentDocRef.delete()].flat())
 }
 
-export { validateEmail, addStudentSurveyResponse, removeStudent }
+export { addStudentSurveyResponse, removeStudent }

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -24,6 +24,17 @@ async function removeStudentFromCourse(
   }
 }
 
+const validateEmail = async (email: string) => {
+  const emailRegex = /^\w+@cornell.edu$/
+  // if true => valid email. if false => invalid email.
+  const validEmail = emailRegex.test(email)
+  console.log(validEmail)
+  if (validEmail === false) {
+    throw new Error('Invalid Email Form')
+  }
+  return true
+}
+
 // Note: the error handling in this file is done the way it is so it is easier
 // to decide response codes based on error type.
 const addStudentSurveyResponse = async (
@@ -175,4 +186,4 @@ async function removeStudent(email: string) {
   await Promise.all([courseUpdates, studentDocRef.delete()].flat())
 }
 
-export { addStudentSurveyResponse, removeStudent }
+export { validateEmail, addStudentSurveyResponse, removeStudent }

--- a/backend/functions/src/student/routes.ts
+++ b/backend/functions/src/student/routes.ts
@@ -4,11 +4,7 @@ import { logger } from 'firebase-functions'
 import { checkAuth } from '../middleware/auth-middleware'
 const router = Router()
 
-import {
-  validateEmail,
-  addStudentSurveyResponse,
-  removeStudent,
-} from './functions'
+import { addStudentSurveyResponse, removeStudent } from './functions'
 
 router.post('/survey', (req, res) => {
   const { name, email, college, year, courseCatalogNames } = req.body
@@ -16,29 +12,18 @@ router.post('/survey', (req, res) => {
   logger.info(
     `Student [${name}] submitted survey using ${email} on agent ${userAgent}`
   )
-  const surveryErrLog = (err: Error) =>
-    logger.error(
-      `ERROR in Student [${name}] submitted survey using ${email} on agent ${userAgent}`,
-      err.message
-    )
 
-  validateEmail(email)
-    .then(() =>
-      addStudentSurveyResponse(name, email, college, year, courseCatalogNames)
-        .then(() => res.status(200).json({ success: true }))
-        .catch((err) => {
-          surveryErrLog(err)
-          if (err.name === 'processing_err') {
-            return res
-              .status(500)
-              .send({ success: false, message: err.message })
-          }
-          return res.status(400).send({ success: false, message: err.message })
-        })
-    )
+  addStudentSurveyResponse(name, email, college, year, courseCatalogNames)
+    .then(() => res.status(200).json({ success: true }))
     .catch((err) => {
-      surveryErrLog(err)
-      return res.status(500).send({ success: false, message: err.message })
+      logger.error(
+        `ERROR in Student [${name}] submitted survey using ${email} on agent ${userAgent}`,
+        err.message
+      )
+      if (err.name === 'processing_err') {
+        return res.status(500).send({ success: false, message: err.message })
+      }
+      return res.status(400).send({ success: false, message: err.message })
     })
 })
 


### PR DESCRIPTION
### Summary 

This PR validates emails on the backend as well. 

Currently, I did validate email => then(add student survey response). Might have a cleaner implementation? 

Just have to make sure if it doesn't pass the email validation, it also doesn't just add the student data to the db. 

- [x] cornell email regex on email sent in
- [x] returns error if error 

### Test Plan 

1. postman send surveys 
<img width="734" alt="image" src="https://user-images.githubusercontent.com/46132945/175066970-f06b1d2e-e398-433d-ba33-8abf31985461.png">

2. Get error msg
<img width="566" alt="image" src="https://user-images.githubusercontent.com/46132945/175067010-1042888e-8fe9-4aa0-9103-d0fb6ddc1a49.png">

3. check db if added or not 
4. check with valid email form too 


