### PR TITLE
Responsive Survey 

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,6 +23,12 @@ code {
     monospace;
 }
 
+a {
+  text-decoration: none;
+  color: inherit;
+  border-bottom: 2px solid;
+}
+
 @font-face {
   font-family: 'Montserrat';
   font-weight: 300;

--- a/frontend/src/modules/Core/Components/RadioButton.tsx
+++ b/frontend/src/modules/Core/Components/RadioButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { RadioButtonProps } from '@core/Types/FormFieldProps'
 import { StyledLabel, StyledContainer } from '@core/Styles/RadioButton.style'
 import Radio, { RadioProps } from '@mui/material/Radio'
@@ -28,8 +26,7 @@ export const RadioButton = ({
   const containerStyle = {
     display: 'flex',
     justifyContent: 'flex-start',
-    padding: '0rem',
-    paddingRight: '10rem',
+    padding: '5px',
     background: '#FFFFFF',
     boxShadow: '2px 2px 8px rgba(0, 0, 0, 0.15)',
     borderRadius: '11px',

--- a/frontend/src/modules/Core/Questions/Questions.json
+++ b/frontend/src/modules/Core/Questions/Questions.json
@@ -6,7 +6,7 @@
       "CALS": "CALS",
       "AAP": "AAP",
       "A&S": "A&S",
-      "Hotel Admin": "Hotel Administration",
+      "Hotel Admin": "Hotel Administration asfljsak; asdfhasjkdlf s asdfkjldsa ;",
       "Dyson": "Dyson School",
       "Engineering": "Engineering",
       "ILR": "ILR",

--- a/frontend/src/modules/Core/Questions/Questions.json
+++ b/frontend/src/modules/Core/Questions/Questions.json
@@ -6,7 +6,7 @@
       "CALS": "CALS",
       "AAP": "AAP",
       "A&S": "A&S",
-      "Hotel Admin": "Hotel Administration asfljsak; asdfhasjkdlf s asdfkjldsa ;",
+      "Hotel Admin": "Hotel Administration",
       "Dyson": "Dyson School",
       "Engineering": "Engineering",
       "ILR": "ILR",

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -7,17 +7,7 @@ import {
   Typography,
 } from '@mui/material'
 import { ArrowForward } from '@mui/icons-material'
-import {
-  StyledContainer,
-  StyledLeftPanel,
-  StyledRightPanel,
-  StyledFields,
-  StyledWhiteActionText,
-  StyledTeamPic,
-  StyledTitleWrapper,
-  StyledHeaderText,
-  StyledWelcomeText,
-} from 'Survey/Styles/StepBegin.style'
+import { StyledTeamPic } from 'Survey/Styles/StepBegin.style'
 import { StepBeginProps } from 'Survey/Types'
 
 export const StepBegin = ({
@@ -45,20 +35,89 @@ export const StepBegin = ({
   const validEmail = /^\w+@cornell.edu$/
 
   return (
-    <StyledContainer>
-      <StyledLeftPanel>
-        <StyledWhiteActionText>
+    <Box
+      component="main"
+      sx={{
+        backgroundColor: '#fff',
+        boxShadow:
+          '-10px -10px 150px rgba(0, 0, 0, 0.1), 10px 10px 150px rgba(0, 0, 0, 0.1)',
+        display: 'flex',
+        width: {
+          xs: '100%',
+          lg: '80%',
+        },
+        height: {
+          xs: '100%',
+          lg: '86.5%',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: {
+            xs: 'none',
+            lg: 'flex',
+          },
+          width: '50%',
+          flexFlow: 'column nowrap',
+          justifyContent: 'center',
+          alignItems: 'center',
+          background: '#815ed4',
+        }}
+      >
+        <Typography
+          variant="h3"
+          align="center"
+          sx={{
+            fontWeight: '700',
+            fontSize: '24px',
+            color: '#fff',
+            margin: ' 0 3rem',
+          }}
+        >
           LSC can help match you with study partners for your classes!
-        </StyledWhiteActionText>
+        </Typography>
         <StyledTeamPic />
-      </StyledLeftPanel>
-      <StyledRightPanel>
-        <StyledTitleWrapper>
-          <StyledHeaderText>Hi,</StyledHeaderText>
-          <StyledWelcomeText>Find study partners!</StyledWelcomeText>
-        </StyledTitleWrapper>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          width: {
+            xs: '100%',
+            lg: '50%',
+          },
+          flexFlow: 'column nowrap',
+          padding: '36px 3rem',
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              color: '#3d2d49',
+              fontSize: '4.5rem',
+            }}
+          >
+            Hi,
+          </Typography>
+          <Typography
+            sx={{
+              color: '#3d2d49',
+              fontSize: '2.25rem',
+              fontWeight: '300',
+            }}
+          >
+            Find study partners!
+          </Typography>
+        </Box>
 
-        <StyledFields>
+        <Box
+          sx={{
+            display: 'flex',
+            flexFlow: 'column',
+            justifyContent: 'center',
+            margin: '4rem 0',
+          }}
+        >
           <InputLabel htmlFor="name">
             <Typography fontWeight="medium">Name:</Typography>
           </InputLabel>
@@ -90,7 +149,7 @@ export const StepBegin = ({
             helperText={!isValidEmail && 'Invalid Email'}
             FormHelperTextProps={helperTextStyle}
           />
-        </StyledFields>
+        </Box>
         <Box
           sx={{
             marginLeft: 'auto',
@@ -109,7 +168,7 @@ export const StepBegin = ({
           </IconButton>
           <Typography id="next">Next</Typography>
         </Box>
-      </StyledRightPanel>
-    </StyledContainer>
+      </Box>
+    </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import {
-  StyledContainer,
   StyledCoursesWrapper,
   StyledQuestionText,
   StyledWarningText,
 } from 'Survey/Styles/StepCourse.style'
 import { StepCourseProps } from 'Survey/Types'
-import { TextField } from '@mui/material'
+import { TextField, Box } from '@mui/material'
 
 export const StepCourse = ({
   validCourseRe,
@@ -73,7 +72,13 @@ export const StepCourse = ({
     courses.length === 0 ? 'ABC 1100' : '+ Add another course...'
 
   return (
-    <StyledContainer>
+    <Box
+      sx={{
+        width: '100%',
+        margin: 'auto',
+        padding: '15% 5%',
+      }}
+    >
       <StyledQuestionText>
         What course(s) would you like to find study partners for?
       </StyledQuestionText>
@@ -111,6 +116,6 @@ export const StepCourse = ({
           FormHelperTextProps={helperTextStyle}
         />
       </StyledCoursesWrapper>
-    </StyledContainer>
+    </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepCourse.tsx
+++ b/frontend/src/modules/Survey/Components/StepCourse.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 
 import {
-  StyledCoursesWrapper,
   StyledQuestionText,
   StyledWarningText,
 } from 'Survey/Styles/StepCourse.style'
@@ -88,7 +87,15 @@ export const StepCourse = ({
         more than once
       </StyledWarningText>
 
-      <StyledCoursesWrapper>
+      <Box
+        sx={{
+          display: 'flex',
+          flexFlow: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '1rem',
+        }}
+      >
         {courses.map((course, index) => (
           <TextField
             inputProps={{ title: `course ${index} name field` }}
@@ -115,7 +122,7 @@ export const StepCourse = ({
           sx={textFieldStyle}
           FormHelperTextProps={helperTextStyle}
         />
-      </StyledCoursesWrapper>
+      </Box>
     </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -1,9 +1,4 @@
-import {
-  StyledCongratulationsWrapper,
-  StyledLogoWrapper,
-  StyledCheck,
-  StyledContactText,
-} from 'Survey/Styles/StepFinal.style'
+import { StyledCheck } from 'Survey/Styles/StepFinal.style'
 
 import { Box, Typography } from '@mui/material'
 import { StepFinalProps } from 'Survey/Types'
@@ -24,16 +19,23 @@ export const StepFinal = ({
         <Typography
           sx={{
             fontSize: { xs: '1.5rem', md: '2.25rem' },
-            fontWeight: '500',
+            fontWeight: '700',
             color: '#fff',
           }}
         >
-          Congratulations on completing the form! You should receive an email
-          with your team members shortly.
+          Congrats on completing the form!
         </Typography>
-        <StyledContactText>
-          Courses added: {submissionResponse.added.join(', ')}
-        </StyledContactText>
+        <Typography
+          sx={{
+            color: '#fff',
+            fontSize: '1.15rem',
+          }}
+        >
+          You should receive an email with your team members shortly.
+          <br />
+          <strong>Courses added: </strong>
+          {submissionResponse.added.join(', ') || `None`}
+        </Typography>
       </>
     )
   }
@@ -44,20 +46,28 @@ export const StepFinal = ({
         <Typography
           sx={{
             fontSize: { xs: '1.5rem', md: '2.25rem' },
-            fontWeight: '500',
+            fontWeight: '700',
             color: '#fff',
           }}
         >
           Some course(s) could not be found in roster
-          {submissionResponse.roster}. Please double-check that they were
-          spelled correctly, and resubmit the form if needed.
+          {submissionResponse.roster}.
         </Typography>
-        <StyledContactText>
-          Courses added successfully:
-          {submissionResponse.added.join(', ') || 'none'}
+        <Typography
+          sx={{
+            color: '#fff',
+            fontSize: '1.15rem',
+          }}
+        >
+          Please double-check that they were spelled correctly, and resubmit the
+          form if needed.
           <br />
-          Courses not added: {submissionResponse.failed.join(', ')}
-        </StyledContactText>
+          <strong> Courses added successfully: </strong>
+          {submissionResponse.added.join(', ') || 'None'}
+          <br />
+          <strong>Courses not added: </strong>
+          {submissionResponse.failed.join(', ')}
+        </Typography>
       </>
     )
   }
@@ -68,13 +78,21 @@ export const StepFinal = ({
         <Typography
           sx={{
             fontSize: { xs: '2rem', md: '2.25rem' },
-            fontWeight: '500',
+            fontWeight: '700',
             color: '#fff',
           }}
         >
           Something went wrong.
         </Typography>
-        <StyledContactText> Error: {errorMsg}</StyledContactText>
+        <Typography
+          sx={{
+            color: '#fff',
+            fontSize: '1.15rem',
+          }}
+        >
+          {' '}
+          Error: {errorMsg}
+        </Typography>
       </>
     )
   }
@@ -87,11 +105,11 @@ export const StepFinal = ({
         flexFlow: 'column nowrap',
         width: {
           xs: '100vw',
-          md: '80%',
+          lg: '80%',
         },
         height: {
           xs: '100%',
-          md: '90%',
+          lg: '90%',
         },
         justifyContent: 'center',
         alignItems: 'center',
@@ -116,7 +134,7 @@ export const StepFinal = ({
           }}
         >
           {showWarning && <Warning />}
-          {success && <Success />}
+          {success && !showWarning && <Success />}
           {!success && <Error />}
         </Box>
       </Box>
@@ -124,7 +142,7 @@ export const StepFinal = ({
         sx={{
           fontWeight: '400',
           color: '#fff',
-          fontSize: { xs: '1.15rem', md: '1.75rem' },
+          fontSize: { xs: '1.15rem', xl: '1.75rem' },
           margin: '10% 0',
           maxWidth: '699px',
         }}

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -20,17 +20,10 @@ export const StepFinal = ({
 
   const Success = () => {
     return (
-      <Box
-        sx={{
-          width: {
-            xs: '100%',
-            lg: '73%',
-          },
-        }}
-      >
+      <>
         <Typography
           sx={{
-            fontSize: '2.25rem',
+            fontSize: { xs: '1.5rem', md: '2.25rem' },
             fontWeight: '500',
             color: '#fff',
           }}
@@ -41,23 +34,16 @@ export const StepFinal = ({
         <StyledContactText>
           Courses added: {submissionResponse.added.join(', ')}
         </StyledContactText>
-      </Box>
+      </>
     )
   }
 
   const Warning = () => {
     return (
-      <Box
-        sx={{
-          width: {
-            xs: '100%',
-            lg: '73%',
-          },
-        }}
-      >
+      <>
         <Typography
           sx={{
-            fontSize: '2.25rem',
+            fontSize: { xs: '1.5rem', md: '2.25rem' },
             fontWeight: '500',
             color: '#fff',
           }}
@@ -72,23 +58,16 @@ export const StepFinal = ({
           <br />
           Courses not added: {submissionResponse.failed.join(', ')}
         </StyledContactText>
-      </Box>
+      </>
     )
   }
 
   const Error = () => {
     return (
-      <Box
-        sx={{
-          width: {
-            xs: '100%',
-            lg: '73%',
-          },
-        }}
-      >
+      <>
         <Typography
           sx={{
-            fontSize: '2.25rem',
+            fontSize: { xs: '2rem', md: '2.25rem' },
             fontWeight: '500',
             color: '#fff',
           }}
@@ -96,7 +75,7 @@ export const StepFinal = ({
           Something went wrong.
         </Typography>
         <StyledContactText> Error: {errorMsg}</StyledContactText>
-      </Box>
+      </>
     )
   }
 
@@ -106,28 +85,48 @@ export const StepFinal = ({
         background: '#815ed4',
         display: 'flex',
         flexFlow: 'column nowrap',
-        width: '100vw',
-        height: '100vh',
+        width: {
+          xs: '100vw',
+          md: '80%',
+        },
+        height: {
+          xs: '100%',
+          md: '90%',
+        },
         justifyContent: 'center',
         alignItems: 'center',
         alignContent: 'center',
-        paddingBottom: '100px',
+        padding: '5%',
       }}
     >
-      <StyledLogoWrapper>
-        <StyledCongratulationsWrapper>
-          <StyledCheck src={showWarning ? warn : success ? check : xmark} />
+      <Box
+        sx={{
+          display: 'flex',
+          flexFlow: 'row wrap',
+          gap: '48px',
+          width: '100%',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <StyledCheck src={showWarning ? warn : success ? check : xmark} />
+        <Box
+          sx={{
+            maxWidth: '698px',
+          }}
+        >
           {showWarning && <Warning />}
           {success && <Success />}
           {!success && <Error />}
-        </StyledCongratulationsWrapper>
-      </StyledLogoWrapper>
+        </Box>
+      </Box>
       <Typography
         sx={{
           fontWeight: '400',
           color: '#fff',
-          fontSize: '1.5rem',
-          margin: '10% 5%',
+          fontSize: { xs: '1.15rem', md: '1.75rem' },
+          margin: '10% 0',
+          maxWidth: '699px',
         }}
       >
         Contact{' '}

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -1,10 +1,8 @@
 import {
   StyledCongratulationsWrapper,
   StyledLogoWrapper,
-  StyledCongratulationsText,
   StyledCheck,
   StyledContactText,
-  StyledContactWrapper,
 } from 'Survey/Styles/StepFinal.style'
 
 import { Box, Typography } from '@mui/material'
@@ -130,7 +128,6 @@ export const StepFinal = ({
           color: '#fff',
           fontSize: '1.5rem',
           margin: '10% 5%',
-          background: '#815ed4',
         }}
       >
         Contact{' '}

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -22,40 +22,83 @@ export const StepFinal = ({
 
   const Success = () => {
     return (
-      <StyledCongratulationsText>
-        Congratulations on completing the form! You should receive an email with
-        your team members shortly.
-        <br />
+      <Box
+        sx={{
+          width: {
+            xs: '100%',
+            lg: '73%',
+          },
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '2.25rem',
+            fontWeight: '500',
+            color: '#fff',
+          }}
+        >
+          Congratulations on completing the form! You should receive an email
+          with your team members shortly.
+        </Typography>
         <StyledContactText>
           Courses added: {submissionResponse.added.join(', ')}
         </StyledContactText>
-      </StyledCongratulationsText>
+      </Box>
     )
   }
 
   const Warning = () => {
     return (
-      <StyledCongratulationsText>
-        Some course(s) could not be found in roster {submissionResponse.roster}.
-        Please double-check that they were spelled correctly, and resubmit the
-        form if needed.
-        <br />
+      <Box
+        sx={{
+          width: {
+            xs: '100%',
+            lg: '73%',
+          },
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '2.25rem',
+            fontWeight: '500',
+            color: '#fff',
+          }}
+        >
+          Some course(s) could not be found in roster
+          {submissionResponse.roster}. Please double-check that they were
+          spelled correctly, and resubmit the form if needed.
+        </Typography>
         <StyledContactText>
           Courses added successfully:
           {submissionResponse.added.join(', ') || 'none'}
           <br />
           Courses not added: {submissionResponse.failed.join(', ')}
         </StyledContactText>
-      </StyledCongratulationsText>
+      </Box>
     )
   }
 
   const Error = () => {
     return (
-      <StyledCongratulationsText>
-        <Typography> Something went wrong. </Typography>
+      <Box
+        sx={{
+          width: {
+            xs: '100%',
+            lg: '73%',
+          },
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '2.25rem',
+            fontWeight: '500',
+            color: '#fff',
+          }}
+        >
+          Something went wrong.
+        </Typography>
         <StyledContactText> Error: {errorMsg}</StyledContactText>
-      </StyledCongratulationsText>
+      </Box>
     )
   }
 
@@ -64,9 +107,13 @@ export const StepFinal = ({
       sx={{
         background: '#815ed4',
         display: 'flex',
-        flexFlow: 'row wrap',
+        flexFlow: 'column nowrap',
         width: '100vw',
         height: '100vh',
+        justifyContent: 'center',
+        alignItems: 'center',
+        alignContent: 'center',
+        paddingBottom: '100px',
       }}
     >
       <StyledLogoWrapper>
@@ -77,11 +124,21 @@ export const StepFinal = ({
           {!success && <Error />}
         </StyledCongratulationsWrapper>
       </StyledLogoWrapper>
-      <StyledContactWrapper>
-        <StyledContactText>
-          Contact lscstudypartners@cornell.edu with any questions.
-        </StyledContactText>
-      </StyledContactWrapper>
+      <Typography
+        sx={{
+          fontWeight: '400',
+          color: '#fff',
+          fontSize: '1.5rem',
+          margin: '10% 5%',
+          background: '#815ed4',
+        }}
+      >
+        Contact{' '}
+        <a href="mailto:lscstudypartners@cornell.edu">
+          lscstudypartners@cornell.edu
+        </a>{' '}
+        with any questions.
+      </Typography>
     </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -1,13 +1,13 @@
 import {
-  StyledContainer,
   StyledCongratulationsWrapper,
   StyledLogoWrapper,
   StyledCongratulationsText,
-  StyledFullPanel,
   StyledCheck,
   StyledContactText,
   StyledContactWrapper,
 } from 'Survey/Styles/StepFinal.style'
+
+import { Box, Typography } from '@mui/material'
 import { StepFinalProps } from 'Survey/Types'
 import check from '@assets/img/whitecheckmark.svg'
 import warn from '@assets/img/warnbutton.svg'
@@ -20,49 +20,68 @@ export const StepFinal = ({
 }: StepFinalProps) => {
   const showWarning = success && submissionResponse.failed.length !== 0
 
+  const Success = () => {
+    return (
+      <StyledCongratulationsText>
+        Congratulations on completing the form! You should receive an email with
+        your team members shortly.
+        <br />
+        <StyledContactText>
+          Courses added: {submissionResponse.added.join(', ')}
+        </StyledContactText>
+      </StyledCongratulationsText>
+    )
+  }
+
+  const Warning = () => {
+    return (
+      <StyledCongratulationsText>
+        Some course(s) could not be found in roster {submissionResponse.roster}.
+        Please double-check that they were spelled correctly, and resubmit the
+        form if needed.
+        <br />
+        <StyledContactText>
+          Courses added successfully:
+          {submissionResponse.added.join(', ') || 'none'}
+          <br />
+          Courses not added: {submissionResponse.failed.join(', ')}
+        </StyledContactText>
+      </StyledCongratulationsText>
+    )
+  }
+
+  const Error = () => {
+    return (
+      <StyledCongratulationsText>
+        <Typography> Something went wrong. </Typography>
+        <StyledContactText> Error: {errorMsg}</StyledContactText>
+      </StyledCongratulationsText>
+    )
+  }
+
   return (
-    <StyledContainer>
-      <StyledFullPanel>
-        <StyledLogoWrapper>
-          <StyledCongratulationsWrapper>
-            <StyledCheck src={showWarning ? warn : success ? check : xmark} />
-            {showWarning ? (
-              <StyledCongratulationsText>
-                Some course(s) could not be found in roster{' '}
-                {submissionResponse.roster}. Please double-check that they were
-                spelled correctly, and resubmit the form if needed.
-                <br />
-                <StyledContactText>
-                  Courses added successfully:{' '}
-                  {submissionResponse.added.join(', ') || 'none'}
-                  <br />
-                  Courses not added: {submissionResponse.failed.join(', ')}
-                </StyledContactText>
-              </StyledCongratulationsText>
-            ) : success ? (
-              <StyledCongratulationsText>
-                Congratulations on completing the form! You should receive an
-                email with your team members shortly.
-                <br />
-                <StyledContactText>
-                  Courses added: {submissionResponse.added.join(', ')}
-                </StyledContactText>
-              </StyledCongratulationsText>
-            ) : (
-              <StyledCongratulationsText>
-                Something went wrong.
-                <br />
-                <StyledContactText>Error: {errorMsg}</StyledContactText>
-              </StyledCongratulationsText>
-            )}
-          </StyledCongratulationsWrapper>
-        </StyledLogoWrapper>
-        <StyledContactWrapper>
-          <StyledContactText>
-            Contact lscstudypartners@cornell.edu with any questions.
-          </StyledContactText>
-        </StyledContactWrapper>
-      </StyledFullPanel>
-    </StyledContainer>
+    <Box
+      sx={{
+        background: '#815ed4',
+        display: 'flex',
+        flexFlow: 'row wrap',
+        width: '100vw',
+        height: '100vh',
+      }}
+    >
+      <StyledLogoWrapper>
+        <StyledCongratulationsWrapper>
+          <StyledCheck src={showWarning ? warn : success ? check : xmark} />
+          {showWarning && <Warning />}
+          {success && <Success />}
+          {!success && <Error />}
+        </StyledCongratulationsWrapper>
+      </StyledLogoWrapper>
+      <StyledContactWrapper>
+        <StyledContactText>
+          Contact lscstudypartners@cornell.edu with any questions.
+        </StyledContactText>
+      </StyledContactWrapper>
+    </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepTemplate.tsx
+++ b/frontend/src/modules/Survey/Components/StepTemplate.tsx
@@ -38,37 +38,34 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
   return (
     <StepContainer>
       <ProgressBar step={stepNumber} total={totalSteps} />
-      <StyledFullPanel>
-        <StyledWrapper>{children}</StyledWrapper>
+      <StyledWrapper>{children}</StyledWrapper>
+      <ButtonsContainer>
+        <BackButton>
+          <IconButton
+            className="next"
+            onClick={handlePrev}
+            color="secondary"
+            sx={{ boxShadow: 3 }}
+            aria-label="previous button"
+          >
+            <ArrowBack />
+          </IconButton>
+          <div>Prev</div>
+        </BackButton>
 
-        <ButtonsContainer>
-          <BackButton>
-            <IconButton
-              className="next"
-              onClick={handlePrev}
-              color="secondary"
-              sx={{ boxShadow: 3 }}
-              aria-label="previous button"
-            >
-              <ArrowBack />
-            </IconButton>
-            <div>Prev</div>
-          </BackButton>
-
-          <NextButton>
-            <IconButton
-              className="next"
-              onClick={handleNext}
-              disabled={!isStepValid}
-              sx={{ boxShadow: 3 }}
-              aria-label="next button"
-            >
-              {stepNumber === totalSteps ? <Check /> : <ArrowForward />}
-            </IconButton>
-            <div>{stepNumber === totalSteps ? 'Finish!' : 'Next'}</div>
-          </NextButton>
-        </ButtonsContainer>
-      </StyledFullPanel>
+        <NextButton>
+          <IconButton
+            className="next"
+            onClick={handleNext}
+            disabled={!isStepValid}
+            sx={{ boxShadow: 3 }}
+            aria-label="next button"
+          >
+            {stepNumber === totalSteps ? <Check /> : <ArrowForward />}
+          </IconButton>
+          <div>{stepNumber === totalSteps ? 'Finish!' : 'Next'}</div>
+        </NextButton>
+      </ButtonsContainer>
     </StepContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepTemplate.tsx
+++ b/frontend/src/modules/Survey/Components/StepTemplate.tsx
@@ -2,7 +2,11 @@ import React, { FunctionComponent } from 'react'
 import { StepTemplateProps } from 'Survey/Types'
 import {
   StyledWrapper,
+  ButtonsContainer,
+  BackButton,
+  NextButton,
   StyledFullPanel,
+  QuestionContainer,
 } from 'Survey/Styles/StepTemplate.style'
 import { ProgressBar } from '@core/Components/index'
 import { IconButton, Box } from '@mui/material'
@@ -32,21 +36,13 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
   }
 
   return (
-    <Box
-      sx={{
-        backgroundColor: 'white',
-        width: '80%',
-        height: '90%',
-      }}
-    >
+    <QuestionContainer>
       <ProgressBar step={stepNumber} total={totalSteps} />
       <StyledFullPanel>
-        <StyledWrapper style={{ height: '85%', overflowY: 'scroll' }}>
-          {children}
-        </StyledWrapper>
+        <StyledWrapper style={{}}>{children}</StyledWrapper>
 
-        <StyledWrapper style={{ height: '15%', margin: '0% 2%' }}>
-          <Box sx={{ textAlign: 'center', color: 'purple.100' }}>
+        <ButtonsContainer>
+          <BackButton>
             <IconButton
               className="next"
               onClick={handlePrev}
@@ -56,17 +52,10 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
             >
               <ArrowBack />
             </IconButton>
-            <br />
-            Prev
-          </Box>
+            <div>Prev</div>
+          </BackButton>
 
-          <Box
-            sx={{
-              marginLeft: 'auto',
-              textAlign: 'center',
-              color: 'purple.100',
-            }}
-          >
+          <NextButton>
             <IconButton
               className="next"
               onClick={handleNext}
@@ -76,11 +65,10 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
             >
               {stepNumber === totalSteps ? <Check /> : <ArrowForward />}
             </IconButton>
-            <br />
-            {stepNumber === totalSteps ? 'Finish!' : 'Next'}
-          </Box>
-        </StyledWrapper>
+            <div>{stepNumber === totalSteps ? 'Finish!' : 'Next'}</div>
+          </NextButton>
+        </ButtonsContainer>
       </StyledFullPanel>
-    </Box>
+    </QuestionContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepTemplate.tsx
+++ b/frontend/src/modules/Survey/Components/StepTemplate.tsx
@@ -6,10 +6,10 @@ import {
   BackButton,
   NextButton,
   StyledFullPanel,
-  QuestionContainer,
+  StepContainer,
 } from 'Survey/Styles/StepTemplate.style'
 import { ProgressBar } from '@core/Components/index'
-import { IconButton, Box } from '@mui/material'
+import { IconButton } from '@mui/material'
 import { ArrowBack, ArrowForward, Check } from '@mui/icons-material'
 
 export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
@@ -36,10 +36,10 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
   }
 
   return (
-    <QuestionContainer>
+    <StepContainer>
       <ProgressBar step={stepNumber} total={totalSteps} />
       <StyledFullPanel>
-        <StyledWrapper style={{}}>{children}</StyledWrapper>
+        <StyledWrapper>{children}</StyledWrapper>
 
         <ButtonsContainer>
           <BackButton>
@@ -69,6 +69,6 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
           </NextButton>
         </ButtonsContainer>
       </StyledFullPanel>
-    </QuestionContainer>
+    </StepContainer>
   )
 }

--- a/frontend/src/modules/Survey/Components/StepTemplate.tsx
+++ b/frontend/src/modules/Survey/Components/StepTemplate.tsx
@@ -5,11 +5,10 @@ import {
   ButtonsContainer,
   BackButton,
   NextButton,
-  StyledFullPanel,
   StepContainer,
 } from 'Survey/Styles/StepTemplate.style'
 import { ProgressBar } from '@core/Components/index'
-import { IconButton, Box, Typography, CircularProgress } from '@mui/material'
+import { IconButton, Typography, CircularProgress } from '@mui/material'
 import { ArrowBack, ArrowForward, Check } from '@mui/icons-material'
 
 export const StepTemplate: FunctionComponent<StepTemplateProps> = ({

--- a/frontend/src/modules/Survey/Components/StepTemplate.tsx
+++ b/frontend/src/modules/Survey/Components/StepTemplate.tsx
@@ -1,14 +1,8 @@
 import React, { FunctionComponent } from 'react'
 import { StepTemplateProps } from 'Survey/Types'
-import {
-  StyledWrapper,
-  ButtonsContainer,
-  BackButton,
-  NextButton,
-  StepContainer,
-} from 'Survey/Styles/StepTemplate.style'
+import { StyledWrapper } from 'Survey/Styles/StepTemplate.style'
 import { ProgressBar } from '@core/Components/index'
-import { IconButton, Typography, CircularProgress } from '@mui/material'
+import { IconButton, Typography, CircularProgress, Box } from '@mui/material'
 import { ArrowBack, ArrowForward, Check } from '@mui/icons-material'
 
 export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
@@ -23,11 +17,46 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
   const showFinish = stepNumber === totalSteps
 
   return (
-    <StepContainer>
+    <Box
+      sx={{
+        background: '#fff',
+        width: {
+          xs: '100%',
+          lg: '80%',
+        },
+        height: {
+          xs: '100%',
+          lg: '90%',
+        },
+        maxWidth: '1440px',
+        position: 'relative',
+      }}
+    >
       <ProgressBar step={stepNumber} total={totalSteps} />
       <StyledWrapper>{children}</StyledWrapper>
-      <ButtonsContainer>
-        <BackButton>
+      <Box
+        sx={{
+          display: 'flex',
+          flexFlow: 'row',
+          width: '100%',
+          paddingBottom: '20%',
+          paddingTop: '50px',
+          '& > *': {
+            position: {
+              xs: 'absolute',
+              lg: 'static',
+            },
+            textAlign: 'center',
+            color: '#815ed4',
+          },
+        }}
+      >
+        <Box
+          sx={{
+            left: '10%',
+            marginLeft: '15%',
+          }}
+        >
           <IconButton
             className="next"
             onClick={gotoPrevStep}
@@ -38,9 +67,17 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
             <ArrowBack />
           </IconButton>
           <Typography id="previous">Prev</Typography>
-        </BackButton>
+        </Box>
 
-        <NextButton>
+        <Box
+          sx={{
+            right: '10%',
+            marginRight: '15%',
+            marginLeft: {
+              lg: 'auto',
+            },
+          }}
+        >
           <IconButton
             onClick={gotoNextStep}
             disabled={!isStepValid || isSubmittingSurvey}
@@ -56,8 +93,8 @@ export const StepTemplate: FunctionComponent<StepTemplateProps> = ({
             )}
           </IconButton>
           <Typography id="next">{showFinish ? 'Finish!' : 'Next'}</Typography>
-        </NextButton>
-      </ButtonsContainer>
-    </StepContainer>
+        </Box>
+      </Box>
+    </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -93,13 +93,12 @@ export const Survey = () => {
     </SplashBackground>
   ) : currStep === totalSteps + 1 ? (
     // Form confirmation
-    <QuestionBackground>
-      <StepFinal
-        success={surveyError === null}
-        submissionResponse={surveySubmissionResponse!}
-        errorMsg={surveyError != null ? surveyError : ''}
-      />
-    </QuestionBackground>
+
+    <StepFinal
+      success={surveyError === null}
+      submissionResponse={surveySubmissionResponse!}
+      errorMsg={surveyError != null ? surveyError : ''}
+    />
   ) : (
     <QuestionBackground>
       <StepTemplate

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -3,7 +3,10 @@ import React, { useState } from 'react'
 import axios from 'axios'
 import { Question } from '@core/Types'
 import { API_ROOT, STUDENT_API } from '@core/Constants'
-import { StyledContainer1, StyledContainer2 } from 'Survey/Styles/Survey.style'
+import {
+  StyledContainer1 as SplashBackground,
+  StyledContainer2 as QuestionBackground,
+} from 'Survey/Styles/Survey.style'
 import { StepTemplate } from 'Survey/Components/StepTemplate'
 import { StepBegin } from 'Survey/Components/StepBegin'
 import { StepCourse } from 'Survey/Components/StepCourse'
@@ -74,7 +77,7 @@ export const Survey = () => {
       : answers[multipleChoiceIndex] !== ''
 
   return currStep === 1 ? ( // Form landing
-    <StyledContainer1>
+    <SplashBackground>
       <StepBegin
         name={nameAnswer}
         email={emailAnswer}
@@ -82,17 +85,18 @@ export const Survey = () => {
         setEmail={(arg: string) => setEmailAnswer(arg)}
         gotoNextStep={() => setCurrStep((currStep) => currStep + 1)}
       />
-    </StyledContainer1>
-  ) : currStep === totalSteps + 1 ? ( // Form confirmation
-    <StyledContainer2>
+    </SplashBackground>
+  ) : currStep === totalSteps + 1 ? (
+    // Form confirmation
+    <QuestionBackground>
       <StepFinal
         success={surveyError === null}
         submissionResponse={surveySubmissionResponse!}
         errorMsg={surveyError != null ? surveyError : ''}
       />
-    </StyledContainer2>
+    </QuestionBackground>
   ) : (
-    <StyledContainer2>
+    <QuestionBackground>
       <StepTemplate
         setShowError={setShowError}
         isStepValid={isStepValid}
@@ -122,6 +126,6 @@ export const Survey = () => {
           />
         )}
       </StepTemplate>
-    </StyledContainer2>
+    </QuestionBackground>
   )
 }

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -93,12 +93,13 @@ export const Survey = () => {
     </SplashBackground>
   ) : currStep === totalSteps + 1 ? (
     // Form confirmation
-
-    <StepFinal
-      success={surveyError === null}
-      submissionResponse={surveySubmissionResponse!}
-      errorMsg={surveyError != null ? surveyError : ''}
-    />
+    <QuestionBackground>
+      <StepFinal
+        success={surveyError === null}
+        submissionResponse={surveySubmissionResponse!}
+        errorMsg={surveyError != null ? surveyError : ''}
+      />
+    </QuestionBackground>
   ) : (
     <QuestionBackground>
       <StepTemplate

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -1,6 +1,6 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
-import { colors, h1, h2, h3, StyledComponent } from '@core'
+import { StyledComponent } from '@core'
 
 import teamPic from '@assets/img/teamwork.svg'
 
@@ -15,71 +15,3 @@ export const StyledTeamPic = styled(TeamPic)`
   max-width: 100%;
   margin-top: 8rem;
 `
-
-const panel = css`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-`
-
-const halfPanel = css`
-  ${panel};
-  width: 50%;
-`
-
-export const StyledLeftPanel = styled.div`
-  ${halfPanel};
-  align-items: center;
-  background: #815ed4;
-`
-
-export const StyledWhiteActionText = styled.h1`
-  ${h3};
-  color: ${colors.white};
-  text-align: center;
-  font-weight: 600;
-  margin: 0 6rem;
-`
-
-export const StyledRightPanel = styled.div`
-  ${halfPanel};
-  box-sizing: border-box;
-  padding: 0 6rem;
-  @media (max-width: 900px) {
-    width: 100%;
-    padding: 5% 5%;
-  }
-`
-
-export const StyledFields = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  margin: 6rem 0;
-`
-
-export const StyledTitleWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100;
-`
-
-export const StyledHeaderText = styled.text`
-  ${h1};
-  color: ${colors.black};
-  @media (max-width: 900px) {
-    font-size: 4rem;
-    margin-bottom: 10px;
-  }
-`
-
-export const StyledWelcomeText = styled.text`
-  ${h2};
-  font-weight: 300;
-  color: ${colors.black};
-  @media (max-width: 900px) {
-    font-size: 2rem;
-  }
-`
-
-export const StyledTextFieldWrapper = styled.div``

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -50,6 +50,7 @@ export const StyledRightPanel = styled.div`
   padding: 0 6rem;
   @media (max-width: 900px) {
     width: 100%;
+    padding: 5% 5%;
   }
 `
 
@@ -63,6 +64,7 @@ export const StyledFields = styled.div`
 export const StyledTitleWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100;
 `
 
 export const StyledHeaderText = styled.text`

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -31,9 +31,6 @@ export const StyledLeftPanel = styled.div`
   ${halfPanel};
   align-items: center;
   background: #815ed4;
-  @media (max-width: 900px) {
-    display: none;
-  }
 `
 
 export const StyledWhiteActionText = styled.h1`

--- a/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepBegin.style.tsx
@@ -68,12 +68,19 @@ export const StyledTitleWrapper = styled.div`
 export const StyledHeaderText = styled.text`
   ${h1};
   color: ${colors.black};
+  @media (max-width: 900px) {
+    font-size: 4rem;
+    margin-bottom: 10px;
+  }
 `
 
 export const StyledWelcomeText = styled.text`
   ${h2};
   font-weight: 300;
   color: ${colors.black};
+  @media (max-width: 900px) {
+    font-size: 2rem;
+  }
 `
 
 export const StyledErrorText = styled.text`

--- a/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
@@ -2,7 +2,9 @@ import styled from 'styled-components'
 import { h2, h4 } from '@core'
 
 export const StyledContainer = styled.main`
+  width: 100%;
   margin: auto;
+  padding: 15% 5%;
 `
 
 export const StyledQuestionText = styled.h1`

--- a/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepCourse.style.tsx
@@ -1,12 +1,6 @@
 import styled from 'styled-components'
 import { h2, h4 } from '@core'
 
-export const StyledContainer = styled.main`
-  width: 100%;
-  margin: auto;
-  padding: 15% 5%;
-`
-
 export const StyledQuestionText = styled.h1`
   ${h2};
   font-weight: 500;
@@ -22,11 +16,4 @@ export const StyledWarningText = styled.div`
   text-align: center;
   margin: 0px 20%;
   margin-bottom: 50px;
-`
-export const StyledCoursesWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
 `

--- a/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
@@ -1,7 +1,6 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
-import { h2, h3, StyledComponent } from '@core'
-import { StyledContainer as Container } from 'Survey/Styles/StepTemplate.style'
+import { StyledComponent } from '@core'
 import { SuccessIcon } from 'Survey/Types'
 
 import logo from '@assets/img/smallwhitelogo.svg'
@@ -38,57 +37,4 @@ export const StyledCheck = styled(Check)`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-`
-
-export const StyledContainer = styled(Container)`
-  background: #815ed4;
-  display: flex;
-  flex-flow: row wrap;
-`
-
-const panel = css`
-  display: flex;
-  flex-direction: column;
-`
-
-const fullPanel = css`
-  ${panel};
-  height: 100%;
-  width: 100%;
-`
-
-export const StyledFullPanel = styled.div`
-  ${fullPanel}
-`
-
-export const StyledCongratulationsWrapper = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: left;
-  align-items: center;
-  width: 80%;
-  margin-top: 10%;
-`
-export const StyledCongratulationsText = styled.h1`
-  ${h2};
-  font-weight: 500;
-  color: white;
-  width: 73%;
-  @media (max-width: 900px) {
-    width: 100%;
-  }
-`
-export const StyledContactWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  margin-top: 10%;
-  margin: 10% 5%;
-`
-
-export const StyledContactText = styled.text`
-  ${h3};
-  font-weight: 400;
-  color: #ffffff;
 `

--- a/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepFinal.style.tsx
@@ -63,16 +63,20 @@ export const StyledFullPanel = styled.div`
 
 export const StyledCongratulationsWrapper = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   justify-content: left;
   align-items: center;
-  width: 75%;
+  width: 80%;
   margin-top: 10%;
 `
 export const StyledCongratulationsText = styled.h1`
   ${h2};
   font-weight: 500;
   color: white;
+  width: 73%;
+  @media (max-width: 900px) {
+    width: 100%;
+  }
 `
 export const StyledContactWrapper = styled.div`
   display: flex;
@@ -80,6 +84,7 @@ export const StyledContactWrapper = styled.div`
   justify-content: center;
   align-items: center;
   margin-top: 10%;
+  margin: 10% 5%;
 `
 
 export const StyledContactText = styled.text`

--- a/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepRadio.style.tsx
@@ -2,7 +2,11 @@ import styled from 'styled-components'
 import { h2 } from '@core'
 
 export const StyledContainer = styled.main`
-  margin: auto;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  width: 100%;
+  padding: 50px 0;
 `
 
 export const StyledRadioButtonsWrapper = styled.div`
@@ -16,7 +20,7 @@ export const StyledRadioButtonsWrapper = styled.div`
 export const StyledQuestionText = styled.h1`
   ${h2};
   font-weight: 500;
-  line-height: 10px;
+  line-height: 1.2ch;
   text-align: center;
   margin-bottom: 2.5rem;
 `
@@ -24,4 +28,5 @@ export const StyledQuestionText = styled.h1`
 export const StyledFieldSet = styled.fieldset`
   border-style: none;
   border-color: #ffffff;
+  width: 100%;
 `

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -45,8 +45,43 @@ export const StyledContainer = styled.main`
   }
 `
 
+/** Wrapper for the entire Question Component */
+export const QuestionContainer = styled.div`
+  background-color: ${colors.white};
+  width: 80%;
+  height: 90%;
+  max-width: 900px;
+  @media (max-width: 900px) {
+    width: 100%;
+    height: 100%;
+  }
+`
+
 export const StyledWrapper = styled.div`
   display: flex;
+`
+
+export const ButtonsContainer = styled.div`
+  display: flex;
+  position: relative;
+  width: 100%;
+  min-height: 15vh;
+  padding: 40px 0px;
+
+  & > * {
+    position: absolute;
+    bottom: 10%;
+    text-align: center;
+    color: #815ed4;
+  }
+`
+
+// button color should be: #815ED4
+export const BackButton = styled.div`
+  left: 5%;
+`
+export const NextButton = styled.div`
+  right: 5%;
 `
 
 export const StyledPrevButton = styled(GoNextPrevButton)`

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -1,41 +1,6 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
-import progress from '@assets/img/progressbarstep1.svg'
-import { colors, StyledComponent } from '@core'
-import { GoNextPrevButton } from 'Survey/Components/UIElements/GoNextPrevButton'
-
-const ProgressBar = ({ className }: StyledComponent) => (
-  <div className={className}>
-    <img src={progress} alt="progress" />
-  </div>
-)
-
-const panel = css`
-  display: flex;
-  flex-direction: column;
-`
-
-export const fullPanel = css`
-  ${panel};
-  height: 100%;
-  width: 100%;
-`
-
-export const StyledFullPanel = styled.div`
-  ${fullPanel}
-  box-sizing: border-box;
-  width: 100%;
-
-  @media (min-width: 901px) {
-    padding: 1.5rem;
-    position: relative;
-  }
-  background: red;
-`
-
-export const StyledFullPanelNoPadding = styled.div`
-  ${fullPanel}
-`
+import { colors } from '@core'
 
 export const StyledContainer = styled.main`
   height: 86.5%;
@@ -50,19 +15,6 @@ export const StyledContainer = styled.main`
   }
 `
 
-/** Wrapper for the entire Question Component */
-export const StepContainer = styled.div`
-  background-color: ${colors.white};
-  width: 80%;
-  height: 90%;
-  max-width: 1440px;
-  @media (max-width: 900px) {
-    width: 100%;
-    height: 100%;
-  }
-  position: relative;
-`
-
 export const StyledWrapper = styled.div`
   display: flex;
   flex-flow: column;
@@ -73,52 +25,4 @@ export const StyledWrapper = styled.div`
     overflow-y: scroll;
     height: 80%;
   }
-`
-
-export const ButtonsContainer = styled.div`
-  display: flex;
-  width: 100%;
-  padding-bottom: 20%;
-  padding-top: 50px;
-  & > * {
-    position: absolute;
-
-    text-align: center;
-    color: #815ed4;
-  }
-  @media (min-width: 900px) {
-    & > * {
-      position: static;
-    }
-  }
-
-  // background: pink;
-`
-
-// button color should be: #815ED4
-export const BackButton = styled.div`
-  left: 10%;
-  margin-left: 15%;
-`
-export const NextButton = styled.div`
-  right: 10%;
-  margin-right: 15%;
-
-  @media (min-width: 900px) {
-    margin-left: auto;
-  }
-`
-
-export const StyledPrevButton = styled(GoNextPrevButton)`
-  cursor: pointer;
-`
-
-export const StyledNextButton = styled(GoNextPrevButton)`
-  cursor: pointer;
-  margin-left: auto;
-`
-
-export const StyledProgressBar = styled(ProgressBar)`
-  justify-content: left;
-  align-content: left;
 `

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -24,8 +24,12 @@ export const fullPanel = css`
 export const StyledFullPanel = styled.div`
   ${fullPanel}
   box-sizing: border-box;
-  padding: 1.5rem;
   position: relative;
+  width: 100%;
+
+  @media (min-width: 901px) {
+    padding: 1.5rem;
+  }
 `
 
 export const StyledFullPanelNoPadding = styled.div`
@@ -46,7 +50,7 @@ export const StyledContainer = styled.main`
 `
 
 /** Wrapper for the entire Question Component */
-export const QuestionContainer = styled.div`
+export const StepContainer = styled.div`
   background-color: ${colors.white};
   width: 80%;
   height: 90%;
@@ -59,6 +63,7 @@ export const QuestionContainer = styled.div`
 
 export const StyledWrapper = styled.div`
   display: flex;
+  width: 100%;
 `
 
 export const ButtonsContainer = styled.div`
@@ -78,10 +83,10 @@ export const ButtonsContainer = styled.div`
 
 // button color should be: #815ED4
 export const BackButton = styled.div`
-  left: 5%;
+  left: 10%;
 `
 export const NextButton = styled.div`
-  right: 5%;
+  right: 10%;
 `
 
 export const StyledPrevButton = styled(GoNextPrevButton)`

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -24,12 +24,13 @@ export const fullPanel = css`
 export const StyledFullPanel = styled.div`
   ${fullPanel}
   box-sizing: border-box;
-  position: relative;
   width: 100%;
 
   @media (min-width: 901px) {
     padding: 1.5rem;
+    position: relative;
   }
+  background: red;
 `
 
 export const StyledFullPanelNoPadding = styled.div`
@@ -54,39 +55,59 @@ export const StepContainer = styled.div`
   background-color: ${colors.white};
   width: 80%;
   height: 90%;
-  max-width: 900px;
+  max-width: 1440px;
   @media (max-width: 900px) {
     width: 100%;
     height: 100%;
   }
+  position: relative;
+  // background: grey;
 `
 
 export const StyledWrapper = styled.div`
   display: flex;
+  flex-flow: column;
   width: 100%;
+  padding: 0 5%;
+
+  @media (min-width: 901px) {
+    overflow-y: scroll;
+    height: 80%;
+  }
 `
 
 export const ButtonsContainer = styled.div`
   display: flex;
-  position: relative;
   width: 100%;
-  min-height: 15vh;
-  padding: 40px 0px;
-
+  padding-bottom: 20%;
+  padding-top: 50px;
   & > * {
     position: absolute;
-    bottom: 10%;
+
     text-align: center;
     color: #815ed4;
   }
+  @media (min-width: 900px) {
+    & > * {
+      position: static;
+    }
+  }
+
+  // background: pink;
 `
 
 // button color should be: #815ED4
 export const BackButton = styled.div`
   left: 10%;
+  margin-left: 15%;
 `
 export const NextButton = styled.div`
   right: 10%;
+  margin-right: 15%;
+
+  @media (min-width: 900px) {
+    margin-left: auto;
+  }
 `
 
 export const StyledPrevButton = styled(GoNextPrevButton)`

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -61,7 +61,6 @@ export const StepContainer = styled.div`
     height: 100%;
   }
   position: relative;
-  // background: grey;
 `
 
 export const StyledWrapper = styled.div`

--- a/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
+++ b/frontend/src/modules/Survey/Styles/StepTemplate.style.tsx
@@ -39,6 +39,10 @@ export const StyledContainer = styled.main`
   box-shadow: -10px -10px 150px rgba(0, 0, 0, 0.1),
     10px 10px 150px rgba(0, 0, 0, 0.1);
   display: flex;
+  @media (max-width: 900px) {
+    width: 100%;
+    height: 100%;
+  }
 `
 
 export const StyledWrapper = styled.div`

--- a/frontend/src/modules/Survey/Styles/Survey.style.tsx
+++ b/frontend/src/modules/Survey/Styles/Survey.style.tsx
@@ -45,6 +45,10 @@ export const StyledContainer2 = styled.main`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @media (min-width: 901px) {
+    overflow-y: hidden;
+  }
 `
 
 export const StyledLabelText = styled.text`

--- a/frontend/src/modules/Survey/Styles/Survey.style.tsx
+++ b/frontend/src/modules/Survey/Styles/Survey.style.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import bg from '@assets/img/homebg.svg'
 import bg2 from '@assets/img/blobhomebg2.svg'
 
+/** Survey Landing page splash background image. Has the bob overlays. */
 export const StyledContainer1 = styled.main`
   background-image: url(${bg});
   background-position: center;
@@ -26,7 +27,15 @@ export const StyledContainer1 = styled.main`
     z-index: 0;
     object-fit: contain;
   }
+
+  @media (max-width: 900px) {
+    &:before {
+      content: none;
+    }
+  }
 `
+
+/** Survey page background for the questions. */
 export const StyledContainer2 = styled.main`
   height: 100%;
   background-image: url(${bg2});

--- a/frontend/src/modules/Survey/Styles/Survey.style.tsx
+++ b/frontend/src/modules/Survey/Styles/Survey.style.tsx
@@ -24,7 +24,7 @@ export const StyledContainer1 = styled.main`
     position: absolute;
     top: 0;
     left: 0;
-    z-index: 0;
+    z-index: -1;
     object-fit: contain;
   }
 

--- a/frontend/src/modules/Survey/Styles/Survey.style.tsx
+++ b/frontend/src/modules/Survey/Styles/Survey.style.tsx
@@ -38,6 +38,7 @@ export const StyledContainer1 = styled.main`
 /** Survey page background for the questions. */
 export const StyledContainer2 = styled.main`
   height: 100%;
+  width: 100%;
   background-image: url(${bg2});
   background-size: cover;
 


### PR DESCRIPTION
# Summary 

I just wanted to make the survey a bit more responsive and reduce the amount of clipping/display funkiness on smaller screens, particularly mobile screens less than 900 pixels wide. 

The following applies to widths < 900px: 
- [x] full width and height for each step
- [x] no more clipping (from my testing) 
- [x] wider text fields for the beginning step 
- [x] scroll down to see prev/next buttons (no y scroll for radio buttons on smaller width) 
- [x] success screen content wraps rather than clips 

## Test Plan 

On dev tools and mobile view, everything works on the smallest screen size of the preset custom responsive dimensions. 

### Video: 
ignore audio lmao

https://user-images.githubusercontent.com/46132945/175795683-6c1f7913-ed46-4206-b7f5-3c6207d5d217.mov

### Screenshots: 
1. Home 
![image](https://user-images.githubusercontent.com/46132945/175795696-5b04dc7e-7dd1-4a22-88b2-e5bca17e21ad.png)
2. Course Selection:
![image](https://user-images.githubusercontent.com/46132945/175795709-49ad59ee-c2be-41cc-834f-0a21a154b5fe.png)
3. College Selection
![image](https://user-images.githubusercontent.com/46132945/175795700-963f22bc-8563-449a-98af-b2e76fdd5672.png)
![image](https://user-images.githubusercontent.com/46132945/175795715-ea70161d-3fa6-4805-a634-e3f075d7ffd6.png)
4. Year
![image](https://user-images.githubusercontent.com/46132945/175795718-58d27dca-76b1-45ba-a23a-ab1f36f31891.png)
5. Final Screen
![image](https://user-images.githubusercontent.com/46132945/177025270-412fb770-bcff-4d8d-b5ac-f606fa3c7f6a.png)
![image](https://user-images.githubusercontent.com/46132945/177025293-abb4cad5-83f8-482f-8fbb-3fd30184dabf.png)

