### PR TITLE
Emailing individual students frontend implementation

### DIFF
--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -133,8 +133,6 @@ export const sendMails = async (
       },
       data: JSON.stringify(message),
     })
-    logger.info(`Response from the endpoint is: `, response)
-    logger.info(`Reponse status is =  ${response.status}`)
     if (response.status === 202 && parseInt(group) > 0) {
       await updateEmailTimestamp(courseId, group, template)
         .then(() =>

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -133,7 +133,9 @@ export const sendMails = async (
       },
       data: JSON.stringify(message),
     })
-    if (response.status === 202) {
+    logger.info(`Response from the endpoint is: `, response)
+    logger.info(`Reponse status is =  ${response.status}`)
+    if (response.status === 202 && parseInt(group) > 0) {
       await updateEmailTimestamp(courseId, group, template)
         .then(() =>
           logger.info(

--- a/backend/functions/src/utils/add-test-data.ts
+++ b/backend/functions/src/utils/add-test-data.ts
@@ -53,7 +53,7 @@ const addTestStudents = async () => {
     alphabet.map((a) =>
       addStudentSurveyResponse(
         a,
-        `${a}@gmail.com`,
+        `${a}@cornell.edu`,
         selectCollege(),
         selectYear(),
         selectClasses()

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -419,14 +419,6 @@ export const EditZing = () => {
       <Box m={6}>
         <DndProvider backend={HTML5Backend}>
           <Grid container spacing={1} padding={0}>
-            <Button
-              onClick={() =>
-                console.log(`Selected students: ${selectedStudents}`)
-              }
-            >
-              {' '}
-              Students{' '}
-            </Button>
             <UnmatchedGrid
               unmatchedStudents={unmatchedStudents}
               moveStudent={moveStudent}

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import axios, { AxiosResponse } from 'axios'
-import { GroupGrid } from 'EditZing/Components/GroupGrid'
+import GroupCard from 'EditZing/Components/GroupCard'
 import { UnmatchedGrid } from './UnmatchedGrid'
 import { Student } from 'EditZing/Types/Student'
 import { DndProvider } from 'react-dnd'
@@ -337,7 +337,11 @@ export const EditZing = () => {
     handleMenuClose()
   }
   return courseInfo && hasLoadedStudentData ? (
-    <Box>
+    <Box
+      sx={{
+        paddingBottom: '100px',
+      }}
+    >
       {isEmailing && (
         <EmailModal
           selectedGroups={selectedGroups}
@@ -415,15 +419,22 @@ export const EditZing = () => {
 
       <Box m={6}>
         <DndProvider backend={HTML5Backend}>
-          <Grid container spacing={1} padding={0}>
-            <UnmatchedGrid
-              unmatchedStudents={unmatchedStudents}
-              moveStudent={moveStudent}
-              matchStudents={matchStudents}
-              handleAddStudent={handleAddStudent}
-            />
+          <UnmatchedGrid
+            unmatchedStudents={unmatchedStudents}
+            moveStudent={moveStudent}
+            matchStudents={matchStudents}
+            handleAddStudent={handleAddStudent}
+          />
+          <Box
+            sx={{
+              margin: '32px 0',
+              display: 'flex',
+              flexFlow: 'row wrap',
+              gap: '32px',
+            }}
+          >
             {studentGroups.map((studentGroup, index) => (
-              <GroupGrid
+              <GroupCard
                 key={studentGroup.groupNumber}
                 studentList={studentGroup.memberData}
                 groupNumber={studentGroup.groupNumber}
@@ -442,7 +453,7 @@ export const EditZing = () => {
                 handleAddStudent={handleAddStudent}
               />
             ))}
-          </Grid>
+          </Box>
         </DndProvider>
       </Box>
       <Snackbar

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -418,20 +418,24 @@ export const EditZing = () => {
 
       <Box m={6}>
         <DndProvider backend={HTML5Backend}>
-          <UnmatchedGrid
-            unmatchedStudents={unmatchedStudents}
-            moveStudent={moveStudent}
-            matchStudents={matchStudents}
-            handleAddStudent={handleAddStudent}
-          />
           <Box
             sx={{
               margin: '32px 0',
-              display: 'flex',
-              flexFlow: 'row wrap',
               gap: '32px',
+              display: 'grid',
+              gridTemplateColumns:
+                'repeat(auto-fit, minmax(380px, max-content))',
+              justifyContent: 'center',
             }}
           >
+            <Box sx={{ gridColumn: '1 / -1' }}>
+              <UnmatchedGrid
+                unmatchedStudents={unmatchedStudents}
+                moveStudent={moveStudent}
+                matchStudents={matchStudents}
+                handleAddStudent={handleAddStudent}
+              />
+            </Box>
             {studentGroups.map((studentGroup, index) => (
               <GroupCard
                 key={studentGroup.groupNumber}

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -18,7 +18,6 @@ import { MatchLoading } from './MatchLoading'
 import {
   Box,
   Button,
-  Grid,
   Menu,
   MenuItem,
   SvgIcon,

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -336,15 +336,8 @@ export const EditZing = () => {
     )
     handleMenuClose()
   }
-
-  const handleSelectStudents = () => {
-    setIsEmailing(true)
-  }
-
   return courseInfo && hasLoadedStudentData ? (
-    <Box
-    // sx={{ maxWidth: '1440px', marginLeft: 'auto', marginRight: 'auto' }}
-    >
+    <Box>
       {isEmailing && (
         <EmailModal
           selectedGroups={selectedGroups}
@@ -405,9 +398,6 @@ export const EditZing = () => {
             >
               <MenuItem onClick={handleSelectNewlyMatched}>
                 Newly Matched
-              </MenuItem>
-              <MenuItem onClick={handleSelectStudents}>
-                Selected Students
               </MenuItem>
             </Menu>
           </>

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -309,6 +309,15 @@ export const EditZing = () => {
     selectedGroupNumbers.includes(group.groupNumber)
   )
 
+  const [selectedStudents, setSelectedStudents] = useState<string[]>([])
+  const handleAddStudent = (student: string, selected: boolean) => {
+    if (selected) {
+      setSelectedStudents((arr) => [...arr, student])
+    } else {
+      setSelectedStudents(selectedStudents.filter((item) => item !== student))
+    }
+  }
+
   // Open and close the 'Send email to' menu drop down
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const menuOpen = Boolean(anchorEl)
@@ -328,11 +337,16 @@ export const EditZing = () => {
     handleMenuClose()
   }
 
+  const handleSelectStudents = () => {
+    setIsEmailing(true)
+  }
+
   return courseInfo && hasLoadedStudentData ? (
     <Box>
       {isEmailing && (
         <EmailModal
           selectedGroups={selectedGroups}
+          selectedStudents={selectedStudents}
           isEmailing={isEmailing}
           setIsEmailing={setIsEmailing}
           setEmailSent={setEmailSent}
@@ -390,6 +404,9 @@ export const EditZing = () => {
               <MenuItem onClick={handleSelectNewlyMatched}>
                 Newly Matched
               </MenuItem>
+              <MenuItem onClick={handleSelectStudents}>
+                Selected Students
+              </MenuItem>
             </Menu>
           </>
         ) : (
@@ -402,10 +419,19 @@ export const EditZing = () => {
       <Box m={6}>
         <DndProvider backend={HTML5Backend}>
           <Grid container spacing={1} padding={0}>
+            <Button
+              onClick={() =>
+                console.log(`Selected students: ${selectedStudents}`)
+              }
+            >
+              {' '}
+              Students{' '}
+            </Button>
             <UnmatchedGrid
               unmatchedStudents={unmatchedStudents}
               moveStudent={moveStudent}
               matchStudents={matchStudents}
+              handleAddStudent={handleAddStudent}
             />
             {studentGroups.map((studentGroup, index) => (
               <GroupGrid
@@ -424,6 +450,7 @@ export const EditZing = () => {
                 handleChecked={(event) => {
                   editSelectedGroups(studentGroup, event.target.checked)
                 }}
+                handleAddStudent={handleAddStudent}
               />
             ))}
           </Grid>

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -380,7 +380,7 @@ export const EditZing = () => {
           {courseInfo.names.join(', ')} ({courseInfo.roster})
         </Typography>
         <Box flexGrow={2} />
-        {selectedGroupNumbers.length === 0 ? (
+        {selectedGroupNumbers.length === 0 && selectedStudents.length === 0 ? (
           <>
             <Button
               onClick={handleMenuOpen}
@@ -410,7 +410,12 @@ export const EditZing = () => {
             </Menu>
           </>
         ) : (
-          <Button onClick={() => setIsEmailing(!isEmailing)}>
+          <Button
+            disabled={
+              selectedGroupNumbers.length > 0 && selectedStudents.length > 0
+            }
+            onClick={() => setIsEmailing(!isEmailing)}
+          >
             Email selected
           </Button>
         )}

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -342,7 +342,9 @@ export const EditZing = () => {
   }
 
   return courseInfo && hasLoadedStudentData ? (
-    <Box>
+    <Box
+    // sx={{ maxWidth: '1440px', marginLeft: 'auto', marginRight: 'auto' }}
+    >
       {isEmailing && (
         <EmailModal
           selectedGroups={selectedGroups}

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -57,27 +57,22 @@ export const EmailModal = ({
    * @throws error if there are any errors in sending the email
    */
   const sendIndividualEmails = async () => {
-    try {
-      await Promise.all(
-        selectedStudents.map((student) => {
-          const emailRcpts = [student]
-          const emailBody = getBody(selectedTemplate, courseNames.join(', '))
-          const emailSubject = 'Study Partners!'
-          const emailItems = {
-            emailSubject,
-            emailRcpts,
-            emailBody,
-            courseId,
-            groupNum: -1,
-            selectedTemplate,
-          }
-          return sendEmail(emailItems)
-        })
-      )
-    } catch (err) {
-      console.log(`Failed to send individual emails`)
-      throw new Error('Failed to send individual emails')
-    }
+    await Promise.all(
+      selectedStudents.map((student) => {
+        const emailRcpts = [student]
+        const emailBody = getBody(selectedTemplate, courseNames.join(', '))
+        const emailSubject = 'Study Partners!'
+        const emailItems = {
+          emailSubject,
+          emailRcpts,
+          emailBody,
+          courseId,
+          groupNum: -1,
+          selectedTemplate,
+        }
+        return sendEmail(emailItems)
+      })
+    )
   }
 
   /**
@@ -86,28 +81,23 @@ export const EmailModal = ({
    * @throws error if there are any errors in sending the email
    */
   const sendGroupEmails = async () => {
-    try {
-      await Promise.all(
-        selectedGroups.map((group) => {
-          const emailRcpts = groupEmails(group)
-          const emailBody = getBody(selectedTemplate, courseNames.join(', '))
-          const emailSubject = 'Study Partners!'
-          const groupNum = group.groupNumber.toString()
-          const emailItems = {
-            emailSubject,
-            emailRcpts,
-            emailBody,
-            courseId,
-            groupNum,
-            selectedTemplate,
-          }
-          return sendEmail(emailItems)
-        })
-      )
-    } catch (err) {
-      console.log(`Failed to send group emails`)
-      throw new Error('Failed to send group emails')
-    }
+    await Promise.all(
+      selectedGroups.map((group) => {
+        const emailRcpts = groupEmails(group)
+        const emailBody = getBody(selectedTemplate, courseNames.join(', '))
+        const emailSubject = 'Study Partners!'
+        const groupNum = group.groupNumber.toString()
+        const emailItems = {
+          emailSubject,
+          emailRcpts,
+          emailBody,
+          courseId,
+          groupNum,
+          selectedTemplate,
+        }
+        return sendEmail(emailItems)
+      })
+    )
 
     // emailStudents().then((res) => {
     //   if (res === false) failure = true

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -51,13 +51,6 @@ export const EmailModal = ({
     ]
   }
 
-  const individualEmails = (students: string[]) => {
-    return [
-      'lscstudypartners@cornell.edu',
-      ...students.map((email: string) => email),
-    ]
-  }
-
   /**
    * promise that sends emails to each individual student.
    *
@@ -65,8 +58,8 @@ export const EmailModal = ({
    */
   const sendIndividualEmails = async () => {
     await Promise.all(
-      selectedStudents.map(() => {
-        const emailRcpts = individualEmails(selectedStudents)
+      selectedStudents.map((student: string) => {
+        const emailRcpts = [student, 'lscstudypartners@cornell.edu']
         const emailBody = getBody(selectedTemplate, courseNames.join(', '))
         const emailSubject = 'Study Partners!'
         const emailItems = {

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -15,6 +15,7 @@ import { adminSignIn } from '@fire/firebase'
 
 export const EmailModal = ({
   selectedGroups,
+  selectedStudents,
   isEmailing,
   setIsEmailing,
   courseNames,
@@ -50,6 +51,44 @@ export const EmailModal = ({
     ]
   }
 
+  const emailStudents = async () => {
+    // const emailRcpts = selectedStudents
+    // const emailBody = getBody(selectedTemplate, courseNames.join(', '))
+    // const emailSubject = 'Study Partners!'
+    // const emailItems = {
+    //   emailSubject,
+    //   emailRcpts,
+    //   emailBody,
+    //   courseId,
+    //   groupNum: -1,
+    //   selectedTemplate,
+    // }
+    // return sendEmail(emailItems)
+
+    let failure = false
+
+    await Promise.all(
+      selectedStudents.map((student) => {
+        const emailRcpts = [student]
+        const emailBody = getBody(selectedTemplate, courseNames.join(', '))
+        const emailSubject = 'Study Partners!'
+        const emailItems = {
+          emailSubject,
+          emailRcpts,
+          emailBody,
+          courseId,
+          groupNum: -1,
+          selectedTemplate,
+        }
+        return sendEmail(emailItems).then((res) => {
+          if (res === false) failure = true
+        })
+      })
+    )
+
+    return failure
+  }
+
   /**
    * promise that sends emails to each group.
    *
@@ -58,7 +97,7 @@ export const EmailModal = ({
   const sendGroupEmails = async () => {
     let failure = false
 
-    await Promise.all(
+    await Promise.all([
       selectedGroups.map((group) => {
         const emailRcpts = groupEmails(group)
         const emailBody = getBody(selectedTemplate, courseNames.join(', '))
@@ -75,8 +114,28 @@ export const EmailModal = ({
         return sendEmail(emailItems).then((res) => {
           if (res === false) failure = true
         })
-      })
-    )
+      }),
+      selectedStudents.map((student) => {
+        const emailRcpts = [student]
+        const emailBody = getBody(selectedTemplate, courseNames.join(', '))
+        const emailSubject = 'Study Partners!'
+        const emailItems = {
+          emailSubject,
+          emailRcpts,
+          emailBody,
+          courseId,
+          groupNum: -1,
+          selectedTemplate,
+        }
+        return sendEmail(emailItems).then((res) => {
+          if (res === false) failure = true
+        })
+      }),
+    ])
+
+    // emailStudents().then((res) => {
+    //   if (res === false) failure = true
+    // })
 
     return failure
   }

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -51,6 +51,13 @@ export const EmailModal = ({
     ]
   }
 
+  const individualEmails = (students: string[]) => {
+    return [
+      'lscstudypartners@cornell.edu',
+      ...students.map((email: string) => email),
+    ]
+  }
+
   /**
    * promise that sends emails to each individual student.
    *
@@ -58,8 +65,8 @@ export const EmailModal = ({
    */
   const sendIndividualEmails = async () => {
     await Promise.all(
-      selectedStudents.map((student) => {
-        const emailRcpts = [student]
+      selectedStudents.map(() => {
+        const emailRcpts = individualEmails(selectedStudents)
         const emailBody = getBody(selectedTemplate, courseNames.join(', '))
         const emailSubject = 'Study Partners!'
         const emailItems = {
@@ -98,10 +105,6 @@ export const EmailModal = ({
         return sendEmail(emailItems)
       })
     )
-
-    // emailStudents().then((res) => {
-    //   if (res === false) failure = true
-    // })
   }
 
   /**

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -246,7 +246,8 @@ export const EmailModal = ({
           }}
           endIcon={<SendIcon />}
         >
-          Send {selectedGroups.length} Emails
+          Send {selectedGroups.length > 0 && selectedGroups.length}
+          {selectedStudents.length > 0 && selectedStudents.length} Emails
         </Button>
       )
     } else return null
@@ -278,10 +279,14 @@ export const EmailModal = ({
           sx={{ display: 'flex', gap: 1 }}
         >
           <Box component="span">To:</Box>
-          <Box component="span" sx={{ fontWeight: 900 }}>
+          <Box
+            component="span"
+            sx={{ fontWeight: 900, maxWidth: '90%', wordBreak: 'break-word' }}
+          >
             {selectedGroups
               .map(({ groupNumber }) => `Group ${groupNumber}`)
               .join(', ')}
+            {selectedStudents.join(', ')}
           </Box>
         </Typography>
         {step === 0 && <Step0 />}

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -51,44 +51,6 @@ export const EmailModal = ({
     ]
   }
 
-  const emailStudents = async () => {
-    // const emailRcpts = selectedStudents
-    // const emailBody = getBody(selectedTemplate, courseNames.join(', '))
-    // const emailSubject = 'Study Partners!'
-    // const emailItems = {
-    //   emailSubject,
-    //   emailRcpts,
-    //   emailBody,
-    //   courseId,
-    //   groupNum: -1,
-    //   selectedTemplate,
-    // }
-    // return sendEmail(emailItems)
-
-    let failure = false
-
-    await Promise.all(
-      selectedStudents.map((student) => {
-        const emailRcpts = [student]
-        const emailBody = getBody(selectedTemplate, courseNames.join(', '))
-        const emailSubject = 'Study Partners!'
-        const emailItems = {
-          emailSubject,
-          emailRcpts,
-          emailBody,
-          courseId,
-          groupNum: -1,
-          selectedTemplate,
-        }
-        return sendEmail(emailItems).then((res) => {
-          if (res === false) failure = true
-        })
-      })
-    )
-
-    return failure
-  }
-
   /**
    * promise that sends emails to each group.
    *

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { StudentGrid } from 'EditZing/Components/StudentGrid'
+import StudentCard from 'EditZing/Components/StudentCard'
 import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
@@ -8,7 +8,7 @@ import { Box, Tooltip, Grid, Checkbox } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 
 /** the equivalent of Column */
-export const GroupGrid = ({
+const GroupCard = ({
   studentList,
   groupNumber,
   moveStudent,
@@ -56,12 +56,14 @@ export const GroupGrid = ({
   }
 
   return (
-    <Grid item xs={12} sm={6} md={4} lg={3} xl={2.5}>
+    <Box>
       <Box
         onMouseOver={handleMouseOver}
         onMouseOut={handleMouseOut}
         ref={drop}
         sx={{
+          width: '380px',
+          height: '350px',
           padding: '2rem',
           border: 0.5,
           borderColor: selected || isHovering ? 'purple.50' : 'purple.16',
@@ -123,9 +125,16 @@ export const GroupGrid = ({
             }}
           />
         </Box>
-        <Grid container spacing={2}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(112px, max-content))',
+            gap: '16px',
+            justifyContent: 'center',
+          }}
+        >
           {studentList.map((student, index) => (
-            <StudentGrid
+            <StudentCard
               key={index}
               groupNumber={groupNumber}
               student={student}
@@ -133,8 +142,10 @@ export const GroupGrid = ({
               handleAddStudent={handleAddStudent}
             />
           ))}
-        </Grid>
+        </Box>
       </Box>
-    </Grid>
+    </Box>
   )
 }
+
+export default GroupCard

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import StudentCard from 'EditZing/Components/StudentCard'
 import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
 import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
-import { Box, Tooltip, Grid, Checkbox } from '@mui/material'
+import { Box, Tooltip, Checkbox } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 
 /** the equivalent of Column */

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -56,7 +56,7 @@ export const GroupGrid = ({
   }
 
   return (
-    <Grid item xs={12} sm={6} md={4} lg={3}>
+    <Grid item xs={12} sm={6} md={4} lg={3} xl={2.5}>
       <Box
         onMouseOver={handleMouseOver}
         onMouseOut={handleMouseOut}

--- a/frontend/src/modules/EditZing/Components/GroupGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupGrid.tsx
@@ -19,6 +19,7 @@ export const GroupGrid = ({
   addStudentEmailTimestamp,
   selected,
   handleChecked,
+  handleAddStudent,
 }: GroupGridProps) => {
   const tooltips = [
     {
@@ -129,6 +130,7 @@ export const GroupGrid = ({
               groupNumber={groupNumber}
               student={student}
               submissionTime={student.submissionTime}
+              handleAddStudent={handleAddStudent}
             />
           ))}
         </Grid>

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -54,7 +54,7 @@ const StudentCard = ({
             fontWeight: '700',
             fontSize: '14',
             boxShadow: isHovering
-              ? '4px 4px 10px rgba(0, 0, 0, 0.3)'
+              ? '4px 4px 8px rgba(0, 0, 0, 0.3)'
               : '0px 2px 5px rgba(205, 156, 242, 0.2)',
             borderRadius: '10px',
             width: '100%',

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -8,7 +8,7 @@ import Tooltip from '@mui/material/Tooltip'
 import { Checkbox, Box, Typography } from '@mui/material'
 
 /** the equivalent of MoveableItem */
-export const StudentGrid = ({
+const StudentCard = ({
   student,
   groupNumber,
   xsSize = 6,
@@ -37,7 +37,11 @@ export const StudentGrid = ({
   const opacity = isDragging ? '0' : '1.0'
 
   return (
-    <Grid item xs={xsSize} sx={{ minWidth: '112px' }}>
+    <Box
+      sx={{
+        width: '150px',
+      }}
+    >
       <div ref={drag}>
         <Paper
           onMouseOver={() => setIsHovering(true)}
@@ -50,9 +54,13 @@ export const StudentGrid = ({
             fontFamily: 'Montserrat',
             fontWeight: '700',
             fontSize: '14',
-            boxShadow: '0px 2px 5px rgba(205, 156, 242, 0.2)',
+            boxShadow: isHovering
+              ? '4px 4px 10px rgba(0, 0, 0, 0.3)'
+              : '0px 2px 5px rgba(205, 156, 242, 0.2)',
             borderRadius: '10px',
             width: '100%',
+            minHeight: '80px',
+            height: '105px',
           }}
         >
           <Tooltip
@@ -73,8 +81,18 @@ export const StudentGrid = ({
                 position: 'relative',
               }}
             >
-              <Box sx={{ width: '90%' }}>
-                <Typography sx={{ fontWeight: '800', fontSize: '0.875rem' }}>
+              <Box
+                sx={{
+                  width: isHovering || selected ? '75%' : '100%',
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: '800',
+                    fontSize: '0.875rem',
+                    wordBreak: 'break-word',
+                  }}
+                >
                   {student.name}
                 </Typography>
                 <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
@@ -89,19 +107,22 @@ export const StudentGrid = ({
                 color="secondary"
                 checked={selected}
                 onChange={handleChecked}
+                disableRipple
                 sx={{
                   display: selected || isHovering ? '' : 'none',
                   width: '20px',
                   height: '20px',
                   position: 'absolute',
-                  right: '4px',
-                  top: '4px',
+                  right: '1px',
+                  top: '1px',
                 }}
               />
             </Box>
           </Tooltip>
         </Paper>
       </div>
-    </Grid>
+    </Box>
   )
 }
+
+export default StudentCard

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -49,7 +49,7 @@ const StudentCard = ({
           style={{ opacity: opacity }}
           sx={{
             padding: '11px 12px',
-            background: selected ? 'rgba(129, 94, 212, 0.15)' : '#FBF9FF',
+            background: selected ? 'rgba(213, 204, 230, .85)' : '#FBF9FF',
             border: '0.25px solid #C0AEEA',
             fontFamily: 'Montserrat',
             fontWeight: '700',
@@ -63,28 +63,28 @@ const StudentCard = ({
             height: '105px',
           }}
         >
-          <Tooltip
-            disableFocusListener
-            disableTouchListener
-            title={
-              'Requested study partner ' +
-              (submissionTime.getMonth() + 1) +
-              '/' +
-              submissionTime.getDate()
-            }
+          <Box
+            sx={{
+              display: 'flex',
+              flexFlow: 'row nowrap',
+              gap: '13px',
+              position: 'relative',
+            }}
           >
             <Box
               sx={{
-                display: 'flex',
-                flexFlow: 'row nowrap',
-                gap: '13px',
-                position: 'relative',
+                width: isHovering || selected ? '75%' : '100%',
               }}
             >
-              <Box
-                sx={{
-                  width: isHovering || selected ? '75%' : '100%',
-                }}
+              <Tooltip
+                disableFocusListener
+                disableTouchListener
+                title={
+                  'Requested study partner ' +
+                  (submissionTime.getMonth() + 1) +
+                  '/' +
+                  submissionTime.getDate()
+                }
               >
                 <Typography
                   sx={{
@@ -95,30 +95,30 @@ const StudentCard = ({
                 >
                   {student.name}
                 </Typography>
-                <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
-                  {student.email.replace('@cornell.edu', '')}
-                </Typography>
-                <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
-                  {student.year}
-                </Typography>
-              </Box>
-
-              <Checkbox
-                color="secondary"
-                checked={selected}
-                onChange={handleChecked}
-                disableRipple
-                sx={{
-                  display: selected || isHovering ? '' : 'none',
-                  width: '20px',
-                  height: '20px',
-                  position: 'absolute',
-                  right: '1px',
-                  top: '1px',
-                }}
-              />
+              </Tooltip>
+              <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
+                {student.email.replace('@cornell.edu', '')}
+              </Typography>
+              <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
+                {student.year}
+              </Typography>
             </Box>
-          </Tooltip>
+
+            <Checkbox
+              color="secondary"
+              checked={selected}
+              onChange={handleChecked}
+              disableRipple
+              sx={{
+                display: selected || isHovering ? '' : 'none',
+                width: '20px',
+                height: '20px',
+                position: 'absolute',
+                right: '1px',
+                top: '1px',
+              }}
+            />
+          </Box>
         </Paper>
       </div>
     </Box>

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import Paper from '@mui/material/Paper'
-import Grid from '@mui/material/Grid'
 import { STUDENT_TYPE } from 'EditZing/Types/Student'
 import { StudentGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrag } from 'react-dnd'

--- a/frontend/src/modules/EditZing/Components/StudentGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useState } from 'react'
 import { styled } from '@mui/material/styles'
 import Paper from '@mui/material/Paper'
 import Grid from '@mui/material/Grid'
@@ -12,7 +12,7 @@ import {
   StyledStudentText,
 } from 'EditZing/Styles/StudentAndGroup.style'
 import Tooltip from '@mui/material/Tooltip'
-
+import { Checkbox } from '@mui/material'
 const PREFIX = 'StudentGrid'
 
 const classes = {
@@ -51,6 +51,7 @@ export const StudentGrid = ({
   groupNumber,
   xsSize = 6,
   submissionTime,
+  handleAddStudent,
 }: StudentGridProps) => {
   const [{ isDragging }, drag] = useDrag({
     item: {
@@ -64,12 +65,32 @@ export const StudentGrid = ({
     }),
   })
 
+  const [isHovering, setIsHovering] = useState(false)
+  const [selected, setSelected] = useState(false)
+  const handleChecked = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleAddStudent(student.email, e.target.checked)
+    setSelected(!selected)
+  }
+
   const opacity = isDragging ? '0' : '1.0'
 
   return (
     <StyledGrid item xs={xsSize}>
       <div ref={drag}>
-        <Paper style={{ opacity: opacity }} className={classes.paper1}>
+        <Paper
+          onMouseOver={() => setIsHovering(true)}
+          onMouseOut={() => setIsHovering(false)}
+          style={{ opacity: opacity }}
+          className={classes.paper1}
+        >
+          <Checkbox
+            color="secondary"
+            checked={selected}
+            onChange={handleChecked}
+            sx={{
+              display: selected || isHovering ? 'flex' : 'none',
+            }}
+          />
           <Tooltip
             disableFocusListener
             disableTouchListener

--- a/frontend/src/modules/EditZing/Components/StudentGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentGrid.tsx
@@ -1,50 +1,11 @@
 import { useState } from 'react'
-import { styled } from '@mui/material/styles'
 import Paper from '@mui/material/Paper'
 import Grid from '@mui/material/Grid'
 import { STUDENT_TYPE } from 'EditZing/Types/Student'
 import { StudentGridProps } from 'EditZing/Types/ComponentProps'
-// import { genderSVG } from 'EditZing/Styles/InlineSVGs'
-import { colors } from '@core'
 import { useDrag } from 'react-dnd'
-import {
-  StyledStudentDetail,
-  StyledStudentText,
-} from 'EditZing/Styles/StudentAndGroup.style'
 import Tooltip from '@mui/material/Tooltip'
 import { Checkbox, Box, Typography } from '@mui/material'
-const PREFIX = 'StudentGrid'
-
-const classes = {
-  paper1: `${PREFIX}-paper1`,
-  paper2: `${PREFIX}-paper2`,
-}
-
-// should we make it so that when it overflows, then the user can scroll?
-const StyledGrid = styled(Grid)(
-  ({ theme }) => `
-  & .${classes.paper1} {
-    padding: ${theme.spacing(2)};
-    text-align: left;
-    color: ${colors.black};
-    font-family: 'Montserrat';
-    font-weight: 700;
-    font-size: 14;
-    border: 0px solid rgba(205, 156, 242, 0.15);
-    box-shadow: 0px 2px 5px rgba(205, 156, 242, 0.2);
-    border-radius: 10px;
-    //overflow-x: scroll;
-    width: 112px;
-  }
-
-  & .${classes.paper2} {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-top: 2px;
-  }
-`
-)
 
 /** the equivalent of MoveableItem */
 export const StudentGrid = ({
@@ -83,7 +44,7 @@ export const StudentGrid = ({
           onMouseOut={() => setIsHovering(false)}
           style={{ opacity: opacity }}
           sx={{
-            padding: '10px',
+            padding: '11px 12px',
             background: selected ? 'rgba(129, 94, 212, 0.15)' : '#FBF9FF',
             border: '0.25px solid #C0AEEA',
             fontFamily: 'Montserrat',

--- a/frontend/src/modules/EditZing/Components/StudentGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentGrid.tsx
@@ -12,7 +12,7 @@ import {
   StyledStudentText,
 } from 'EditZing/Styles/StudentAndGroup.style'
 import Tooltip from '@mui/material/Tooltip'
-import { Checkbox } from '@mui/material'
+import { Checkbox, Box, Typography } from '@mui/material'
 const PREFIX = 'StudentGrid'
 
 const classes = {
@@ -34,6 +34,7 @@ const StyledGrid = styled(Grid)(
     box-shadow: 0px 2px 5px rgba(205, 156, 242, 0.2);
     border-radius: 10px;
     //overflow-x: scroll;
+    width: 112px;
   }
 
   & .${classes.paper2} {
@@ -75,22 +76,24 @@ export const StudentGrid = ({
   const opacity = isDragging ? '0' : '1.0'
 
   return (
-    <StyledGrid item xs={xsSize}>
+    <Grid item xs={xsSize} sx={{ minWidth: '112px' }}>
       <div ref={drag}>
         <Paper
           onMouseOver={() => setIsHovering(true)}
           onMouseOut={() => setIsHovering(false)}
           style={{ opacity: opacity }}
-          className={classes.paper1}
+          sx={{
+            padding: '10px',
+            background: selected ? 'rgba(129, 94, 212, 0.15)' : '#FBF9FF',
+            border: '0.25px solid #C0AEEA',
+            fontFamily: 'Montserrat',
+            fontWeight: '700',
+            fontSize: '14',
+            boxShadow: '0px 2px 5px rgba(205, 156, 242, 0.2)',
+            borderRadius: '10px',
+            width: '100%',
+          }}
         >
-          <Checkbox
-            color="secondary"
-            checked={selected}
-            onChange={handleChecked}
-            sx={{
-              display: selected || isHovering ? 'flex' : 'none',
-            }}
-          />
           <Tooltip
             disableFocusListener
             disableTouchListener
@@ -101,17 +104,43 @@ export const StudentGrid = ({
               submissionTime.getDate()
             }
           >
-            <StyledStudentText>{student.name}</StyledStudentText>
+            <Box
+              sx={{
+                display: 'flex',
+                flexFlow: 'row nowrap',
+                gap: '13px',
+                position: 'relative',
+              }}
+            >
+              <Box sx={{ width: '90%' }}>
+                <Typography sx={{ fontWeight: '800', fontSize: '0.875rem' }}>
+                  {student.name}
+                </Typography>
+                <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
+                  {student.email.replace('@cornell.edu', '')}
+                </Typography>
+                <Typography sx={{ fontWeight: '400', fontSize: '0.875rem' }}>
+                  {student.year}
+                </Typography>
+              </Box>
+
+              <Checkbox
+                color="secondary"
+                checked={selected}
+                onChange={handleChecked}
+                sx={{
+                  display: selected || isHovering ? '' : 'none',
+                  width: '20px',
+                  height: '20px',
+                  position: 'absolute',
+                  right: '4px',
+                  top: '4px',
+                }}
+              />
+            </Box>
           </Tooltip>
-          <div className={classes.paper2}>
-            {/* {genderSVG} {student.pronoun === 'a' ? 'Male' : 'Female'} */}
-            <StyledStudentDetail>
-              {student.email.replace('@cornell.edu', '')}
-            </StyledStudentDetail>
-            <StyledStudentDetail>{student.year}</StyledStudentDetail>
-          </div>
         </Paper>
       </div>
-    </StyledGrid>
+    </Grid>
   )
 }

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material'
-import { StudentGrid } from 'EditZing/Components/StudentGrid'
+import StudentCard from 'EditZing/Components/StudentCard'
 import Grid, { GridSize } from '@mui/material/Grid'
 import { UnmatchedGridProps } from 'EditZing/Types/ComponentProps'
 import {
@@ -43,7 +43,7 @@ export const UnmatchedGrid = ({
         </StyledUnmatchedTextWrapper>
         <Box sx={{ display: 'flex', flexFlow: 'row wrap', gap: '8px' }}>
           {unmatchedStudents.map((student, index) => (
-            <StudentGrid
+            <StudentCard
               key={index}
               groupNumber={-1}
               student={student}

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -16,6 +16,7 @@ export const UnmatchedGrid = ({
   unmatchedStudents,
   moveStudent,
   matchStudents,
+  handleAddStudent,
 }: UnmatchedGridProps) => {
   const [{ isOver }, drop] = useDrop({
     accept: STUDENT_TYPE,
@@ -48,6 +49,7 @@ export const UnmatchedGrid = ({
               student={student}
               xsSize={xsSize}
               submissionTime={student.submissionTime}
+              handleAddStudent={handleAddStudent}
             />
           ))}
         </Grid>

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { Box } from '@mui/material'
 import { StudentGrid } from 'EditZing/Components/StudentGrid'
 import Grid, { GridSize } from '@mui/material/Grid'
 import { UnmatchedGridProps } from 'EditZing/Types/ComponentProps'
@@ -41,7 +41,7 @@ export const UnmatchedGrid = ({
           </StyledUnmatchedText>
           <MatchButton label="Match" onClick={matchStudents} />
         </StyledUnmatchedTextWrapper>
-        <Grid container spacing={2}>
+        <Box sx={{ display: 'flex', flexFlow: 'row wrap', gap: '8px' }}>
           {unmatchedStudents.map((student, index) => (
             <StudentGrid
               key={index}
@@ -52,7 +52,7 @@ export const UnmatchedGrid = ({
               handleAddStudent={handleAddStudent}
             />
           ))}
-        </Grid>
+        </Box>
       </StyledUnmatchedContainer>
     </Grid>
   )

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -11,6 +11,7 @@ export interface UnmatchedGridProps {
     toGroupNumber: number
   ) => void
   matchStudents: () => void
+  handleAddStudent: (student: string, selected: boolean) => void
 }
 
 export interface GroupGridProps {
@@ -28,6 +29,7 @@ export interface GroupGridProps {
   updateTime: Date
   selected: boolean
   handleChecked: (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleAddStudent: (student: string, selected: boolean) => void
 }
 
 export interface StudentGridProps {
@@ -35,6 +37,7 @@ export interface StudentGridProps {
   groupNumber: number
   xsSize?: GridSize
   submissionTime: Date
+  handleAddStudent: (student: string, selected: boolean) => void
 }
 
 export interface MatchLoadingProps {
@@ -46,6 +49,7 @@ export interface MatchLoadingProps {
 }
 
 export interface EmailModalProps {
+  selectedStudents: string[]
   selectedGroups: Group[]
   isEmailing: boolean
   setIsEmailing: (arg: boolean) => void

--- a/frontend/src/modules/Emailing/Components/Emailing.tsx
+++ b/frontend/src/modules/Emailing/Components/Emailing.tsx
@@ -176,6 +176,7 @@ export const sendEmail = async (emailItems: any) => {
       // handle error
       emailSent = false
       console.log('Email send error. Please try again.')
+      console.log(res)
 
       /* firebase login requires user action (ie. press button) will throw error 
           if we try to call it straight up. 

--- a/frontend/src/modules/Emailing/Components/Emailing.tsx
+++ b/frontend/src/modules/Emailing/Components/Emailing.tsx
@@ -177,6 +177,7 @@ export const sendEmail = async (emailItems: any) => {
       emailSent = false
       console.log('Email send error. Please try again.')
       console.log(res)
+      throw new Error(`API call to send email failed.`)
 
       /* firebase login requires user action (ie. press button) will throw error 
           if we try to call it straight up. 


### PR DESCRIPTION
# Summary 

PR to allow emailing individual students. 

Currently, utilizes the same email modal as we use to send group emails. As of now, it is working for me. 

Possible changes: 
- conditionally render different template/modal content based on selectedGroups/selectedStudents etc... 
- or just make a new modal (more work but simpler)

### Test Plan <!-- Required -->

1. Selecting students
![image](https://user-images.githubusercontent.com/46132945/177017003-d9153d71-87c9-48b9-84ce-3590ed23a2c1.png)
2. Selecting both students + groups is disabled
![image](https://user-images.githubusercontent.com/46132945/177017008-e00b2ef2-b73d-4647-9588-ad2e4c47fcdd.png)
3. Student Emails populate the `To:` field 
![image](https://user-images.githubusercontent.com/46132945/177017021-60495e4b-cc50-4365-9ed5-fd8a90a07d13.png)
4. Has correct number of emails to be sent: 
![image](https://user-images.githubusercontent.com/46132945/177017033-efd5e486-efb2-4323-92dd-2b9c75d2f7f6.png)
5. Checkbox handling overflows:
![image](https://user-images.githubusercontent.com/46132945/177021064-fe65d656-3651-4a07-a543-4b57040b354d.png)
6. New style:
![image](https://user-images.githubusercontent.com/46132945/177024106-21494340-d461-474a-9810-314649bbfc32.png)
![image](https://user-images.githubusercontent.com/46132945/177024114-927dee4b-e899-439c-8b65-0650cd492091.png)





