### PR TITLE
Notes backend

### DIFF
--- a/backend/functions/src/config.ts
+++ b/backend/functions/src/config.ts
@@ -1,6 +1,4 @@
 import admin from 'firebase-admin'
-import { config } from 'dotenv'
-config()
 
 const serviceAccount: string = require('../service-account.json')
 

--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -1,21 +1,6 @@
-require('dotenv').config({ path: '../.env' })
-
 import { db } from '../config'
+import { getStudentsData } from '../student/functions'
 const courseRef = db.collection('courses')
-const studentRef = db.collection('students')
-
-async function getStudent(email: string) {
-  const snapshot = await studentRef.doc(email).get()
-  if (!snapshot.exists) throw new Error(`Student ${email} does not exist`)
-  const result: any = snapshot.data()
-  result.email = email
-  result.submissionTime = result.submissionTime.toDate()
-  return result
-}
-
-async function getDataForStudents(emails: string[]) {
-  return Promise.all(emails.map((email) => getStudent(email)))
-}
 
 async function getCourseInfo(courseId: string) {
   const snapshot = await courseRef.doc(courseId).get()
@@ -47,9 +32,9 @@ async function getStudentsForCourse(courseId: string) {
   ).docs
 
   const data = groupsQueryDocSnapshots.map((snapshot) => snapshot.data())
-  const unmatchedStudentData = await getDataForStudents(unmatched)
+  const unmatchedStudentData = await getStudentsData(unmatched)
   const groupStudentDataRaw = await Promise.all(
-    data.map((group) => getDataForStudents(group.members))
+    data.map((group) => getStudentsData(group.members))
   )
 
   const groupStudentData = groupStudentDataRaw.map((groupData, index) => ({
@@ -74,9 +59,4 @@ async function getStudentsForCourse(courseId: string) {
   }
 }
 
-export {
-  getDataForStudents,
-  getCourseInfo,
-  getAllCourses,
-  getStudentsForCourse,
-}
+export { getCourseInfo, getAllCourses, getStudentsForCourse }

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -9,8 +9,6 @@ import {
 } from './middleware/auth-middleware'
 import { unless } from './middleware/unless'
 
-require('dotenv').config({ path: '../.env' })
-
 // import routers
 import studentsRouter from './student/routes'
 import matchingRouter from './matching/routes'

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -7,6 +7,7 @@ import {
   checkIsAuthorized,
   checkIsAuthorizedFromToken,
 } from './middleware/auth-middleware'
+import { unless } from './middleware/unless'
 
 require('dotenv').config({ path: '../.env' })
 
@@ -31,7 +32,11 @@ app.use(express.json())
 app.use(cors())
 
 // auth middleware before router
-app.use('/student', studentsRouter)
+app.use(
+  '/student',
+  [unless(checkAuth, '/survey'), unless(checkIsAuthorized, '/survey')],
+  studentsRouter
+)
 app.use('/matching', [checkAuth, checkIsAuthorized], matchingRouter)
 app.use('/course', [checkAuth, checkIsAuthorized], courseRouter)
 app.use('/email', emailRouter)

--- a/backend/functions/src/middleware/unless.ts
+++ b/backend/functions/src/middleware/unless.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+
+/** Use middleware unless the path is: */
+export const unless =
+  (middleware: RequestHandler, ...paths: string[]) =>
+  (req: Request, res: Response, next: NextFunction) =>
+    paths.some((path) => path === req.path)
+      ? next()
+      : middleware(req, res, next)

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -17,6 +17,10 @@ export const getStudentData = async (email: string) => {
   }
   studentData.email = email
   studentData.submissionTime = studentData.submissionTime.toDate()
+  studentData.groups = studentData.groups.map((group: any) => ({
+    ...group,
+    notesModifyTime: group.notesModifyTime.toDate(),
+  }))
   return studentData as Student
 }
 

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -115,10 +115,15 @@ const addStudentSurveyResponse = async (
     (course) => !existingCourseIds.includes(course.courseId)
   )
 
+  // Can't use serverTimestamp in arrays (error), but want to have same timestamp for everything here
+  const surveyTimestamp = admin.firestore.Timestamp.now()
+
   // Map to group membership objects for the student
   const newCourses = newCourseIdsWithNames.map((course) => ({
     courseId: course.courseId,
     groupNumber: -1,
+    notes: '',
+    notesModifyTime: surveyTimestamp, // Can't use serverTimestamp in arrays...
   }))
 
   // First, update the [student] collection to include the data for the new student
@@ -129,7 +134,7 @@ const addStudentSurveyResponse = async (
       college,
       year,
       groups: [...existingCourses, ...newCourses],
-      submissionTime: admin.firestore.FieldValue.serverTimestamp(),
+      submissionTime: surveyTimestamp,
     })
     .catch((err) => {
       console.log(err)

--- a/backend/functions/src/student/routes.ts
+++ b/backend/functions/src/student/routes.ts
@@ -27,6 +27,11 @@ router.post('/survey', (req, res) => {
     })
 })
 
+router.post('/notes', (req, res) => {
+  logger.log('notes')
+  res.sendStatus(418)
+})
+
 router.delete('/', checkAuth, (req, res) => {
   const email = req.body.studentEmail
   logger.info(`Student [${email}] deleted.`)

--- a/backend/functions/src/student/routes.ts
+++ b/backend/functions/src/student/routes.ts
@@ -4,7 +4,11 @@ import { logger } from 'firebase-functions'
 import { checkAuth } from '../middleware/auth-middleware'
 const router = Router()
 
-import { addStudentSurveyResponse, removeStudent } from './functions'
+import {
+  addStudentSurveyResponse,
+  removeStudent,
+  updateStudentNotes,
+} from './functions'
 
 router.post('/survey', (req, res) => {
   const { name, email, college, year, courseCatalogNames } = req.body
@@ -28,8 +32,15 @@ router.post('/survey', (req, res) => {
 })
 
 router.post('/notes', (req, res) => {
-  logger.log('notes')
-  res.sendStatus(418)
+  const { email, courseId, notes } = req.body
+  updateStudentNotes(email, courseId, notes)
+    .then(() => res.status(200).send({ success: true }))
+    .catch((err) => {
+      logger.error(
+        `Error updating notes for [${courseId}] in student [${email}] to [${notes}]: ${err.message}`
+      )
+      res.status(400).send({ success: false, message: err.message })
+    })
 })
 
 router.delete('/', checkAuth, (req, res) => {

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -16,4 +16,6 @@ export type Student = {
 export type GroupMembership = {
   courseId: string
   groupNumber: number
+  notes: string
+  notesModifyTime: Date
 }

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -1,0 +1,19 @@
+// For now this exists in the backend folder only
+// Future: become a cool monorepo and have shared types backend/frontend
+
+/** Student data. This is not exactly how it's stored in the database, since
+ *  email is the document ID but not actually in the doc. Don't write to db */
+export type Student = {
+  name: string
+  email: string
+  college: string
+  year: string
+  submissionTime: Date
+  groups: GroupMembership[]
+}
+
+/** Student's membership in a course */
+export type GroupMembership = {
+  courseId: string
+  groupNumber: number
+}

--- a/backend/functions/src/utils/add-authorized-users.ts
+++ b/backend/functions/src/utils/add-authorized-users.ts
@@ -1,5 +1,5 @@
 require('dotenv').config({ path: '../../.env' })
-const { db } = require('../config')
+import { db } from '../config'
 
 const usersRef = db.collection('allowed_users')
 

--- a/backend/functions/src/utils/add-test-data.ts
+++ b/backend/functions/src/utils/add-test-data.ts
@@ -53,7 +53,7 @@ const addTestStudents = async () => {
     alphabet.map((a) =>
       addStudentSurveyResponse(
         a,
-        `${a}@gmail.com`,
+        `${a}@cornell.edu`,
         selectCollege(),
         selectYear(),
         selectClasses()


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing student notes on a per-class basis. It sets up the backend and database to handle tracking a notes string for each class a student is in. Since the new route uses the student router that also has to handle public survey requests (until we add student sign in) I had to add a new middleware that secures all routes except for `/survey`.

Also included is factoring out `getStudent` and adding a `Student` type (finally!) to the backend. Not everywhere has been migrated yet. Also prefer `Timestamp.now()` instead of `serverTimestamp()` in some situations going forward because it's better to be consistent for things updated in the same function execution instead of when exactly things are written to the backend, since those times may differ by fractions of a second. Also updated `utils/add-test-data.ts` to use `@cornell.edu` emails.

- [x] implemented backend route for updating notes
- [x] existing backend routes that get student data get note modification timestamp in right format
- [x] other code improvement

POST `/student/notes` request to update notes for a student for a particular class:
```json
{
  "email": "a@cornell.edu",
  "courseId": "SU22-358526",
  "notes": "notes test"
}
```

New group membership type for students. `notesModifyTime` is sent as a stringified Date object, need to convert it back to a Date on the frontend like `submissionTime` and others. `notes` will always exist as a field, empty notes are represented by empty strings:
```json
"groups": [
  {
    "notesModifyTime": "2022-07-02T07:24:17.155Z",
    "notes": "notes test",
    "courseId": "SU22-358526",
    "groupNumber": 1
  },
  {
    "notesModifyTime": "2022-07-02T07:22:10.923Z",
    "notes": "",
    "courseId": "SU22-358546",
    "groupNumber": -1
  }
],
```

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Success input/output for POST `/student/notes`

<img width="865" alt="Screen Shot 2022-07-02 at 00 39 33" src="https://user-images.githubusercontent.com/22627336/176991532-0d5e89a5-1a5e-4c9c-a282-2c52bca67457.png">

Error outputs for POST `/student/notes`

<img width="497" alt="Screen Shot 2022-07-02 at 00 44 48" src="https://user-images.githubusercontent.com/22627336/176991733-9b992dee-b730-4163-8494-0f473d9d7c32.png">

<img width="496" alt="Screen Shot 2022-07-02 at 00 44 37" src="https://user-images.githubusercontent.com/22627336/176991736-864a23e7-1875-4ede-8d25-4fcbfdf87603.png">

Output from GET `/course/students/SU22-358526`

<img width="490" alt="Screen Shot 2022-07-02 at 00 25 01" src="https://user-images.githubusercontent.com/22627336/176991531-b7e7b6f8-1b5b-40a2-9d55-0051cce8be12.png">

Output from POST `/matching/make` (one unmatched student, but same if there are matched students)

<img width="497" alt="Screen Shot 2022-07-02 at 00 25 43" src="https://user-images.githubusercontent.com/22627336/176991533-2acdec24-9801-4d2c-8da6-fe4a6a7c0274.png">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

Spent a lot of time figuring out why my changes weren't being built. Old files remained in the `lib` folder and I didn't even know what was going on because there were no error messages, the code I was writing just didn't do anything. Turns out that trying to import service account as an ES6 import and typing it as ServiceAccount changes the folder structure of the output, nestling everything in src/lib... I didn't notice because it was using my old compiled files!

### Breaking Changes

- Fields for `notes` and `notesModifyTime` are required to exist or loading the edit page will fail. Need to update database accordingly