### PR TITLE
survey first page styling

### DIFF
--- a/frontend/src/modules/Core/Components/RadioButton.tsx
+++ b/frontend/src/modules/Core/Components/RadioButton.tsx
@@ -27,7 +27,6 @@ export const RadioButton = ({
     display: 'flex',
     justifyContent: 'flex-start',
     padding: '0.5rem',
-    minWidth: '35rem',
     maxWidth: '60rem',
     background: '#FFFFFF',
     boxShadow: '2px 2px 8px rgba(0, 0, 0, 0.15)',

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -70,12 +70,13 @@ export const StepBegin = ({
           align="center"
           sx={{
             fontWeight: '700',
-            fontSize: '24px',
+            fontSize: '1.75rem',
             color: '#fff',
             margin: ' 0 3rem',
           }}
         >
-          LSC can help match you with study partners for your classes!
+          Cornell's Learning Strategies Center can help match Cornell students
+          with study partners!
         </Typography>
         <StyledTeamPic />
       </Box>
@@ -88,6 +89,7 @@ export const StepBegin = ({
           },
           flexFlow: 'column nowrap',
           padding: '36px 3rem',
+          justifyContent: 'center',
         }}
       >
         <Box>
@@ -95,6 +97,7 @@ export const StepBegin = ({
             sx={{
               color: '#3d2d49',
               fontSize: '4.5rem',
+              fontWeight: '500',
             }}
           >
             Hi,
@@ -103,7 +106,7 @@ export const StepBegin = ({
             sx={{
               color: '#3d2d49',
               fontSize: '2.25rem',
-              fontWeight: '300',
+              fontWeight: '400',
             }}
           >
             Find study partners!

--- a/frontend/src/modules/Survey/Components/StepFinal.tsx
+++ b/frontend/src/modules/Survey/Components/StepFinal.tsx
@@ -50,7 +50,7 @@ export const StepFinal = ({
             color: '#fff',
           }}
         >
-          Some course(s) could not be found in roster
+          Some course(s) could not be found in roster{' '}
           {submissionResponse.roster}.
         </Typography>
         <Typography


### PR DESCRIPTION
### Summary 

This PR changes so the first step of the survey is centered vertically on the right panel. 

Also changes the left panel text to match the fulling spelling out LSC. 

Also removes the min width of the radio buttons which doesn't fit on smaller screen sizes. 

### Test Plan 

My regular width (1600px): (changed to strategies)
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/46132945/177623716-5995fdc1-d73f-411a-aec5-7e3108233e55.png">
On 75% zoom: 
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/46132945/177623776-b7072e66-6b38-41c8-9900-ec812b69a4f9.png">

Adds space:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/46132945/177624099-312c6ee0-594c-445c-b812-455f3e1add46.png">

