### PR TITLE
Track survey timestamp per class

### DIFF
--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -5,23 +5,26 @@ import {
   mapCatalogNameToCourseId,
   MissingCourseError,
 } from '../course/get_course_id'
-import { Student } from '../types'
+import { FirestoreStudent, Student } from '../types'
 const courseRef = db.collection('courses')
 const studentRef = db.collection('students')
 
 /** Get student data as Student type (with email and timestamps as Date) */
 export const getStudentData = async (email: string) => {
-  const studentData = (await studentRef.doc(email).get()).data()
-  if (!studentData) {
+  const studentDoc = await studentRef.doc(email).get()
+  if (!studentDoc.exists) {
     throw new Error(`Student document for ${email} does not exist`)
   }
-  studentData.email = email
-  studentData.groups = studentData.groups.map((group: any) => ({
-    ...group,
-    notesModifyTime: group.notesModifyTime.toDate(),
-    submissionTime: group.submissionTime.toDate(),
-  }))
-  return studentData as Student
+  const studentData = studentDoc.data() as FirestoreStudent
+  return {
+    ...studentData,
+    email,
+    groups: studentData.groups.map((group) => ({
+      ...group,
+      notesModifyTime: group.notesModifyTime.toDate(),
+      submissionTime: group.submissionTime.toDate(),
+    })),
+  } as Student
 }
 
 /** Get multiple student data as Student type (email + timestamps as Date) */
@@ -258,17 +261,14 @@ export const updateStudentNotes = async (
   courseId: string,
   notes: string
 ) => {
-  const studentDoc = studentRef.doc(email)
-  const studentData = (await studentDoc.get()).data()
-  if (!studentData) {
+  const studentDocRef = studentRef.doc(email)
+  const studentDoc = await studentDocRef.get()
+  if (!studentDoc.exists) {
     throw new Error(`Student document for ${email} does not exist`)
   }
+  const studentData = studentDoc.data() as FirestoreStudent
 
-  const groups: {
-    courseId: string
-    notes: string
-    notesModifyTime: admin.firestore.Timestamp
-  }[] = studentData.groups
+  const groups = studentData.groups
   const groupMembership = groups.find((group) => group.courseId === courseId)
   if (!groupMembership) {
     throw new Error(`Student ${email} does not have membership in ${courseId}`)
@@ -277,7 +277,7 @@ export const updateStudentNotes = async (
   groupMembership.notes = notes
   groupMembership.notesModifyTime = admin.firestore.Timestamp.now()
 
-  await studentDoc.update({ groups })
+  await studentDocRef.update({ groups })
   logger.info(
     `Updated notes for [${courseId}] in student [${email}] to [${notes}]`
   )

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -16,10 +16,10 @@ export const getStudentData = async (email: string) => {
     throw new Error(`Student document for ${email} does not exist`)
   }
   studentData.email = email
-  studentData.submissionTime = studentData.submissionTime.toDate()
   studentData.groups = studentData.groups.map((group: any) => ({
     ...group,
     notesModifyTime: group.notesModifyTime.toDate(),
+    submissionTime: group.submissionTime.toDate(),
   }))
   return studentData as Student
 }
@@ -142,6 +142,7 @@ export const addStudentSurveyResponse = async (
     groupNumber: -1,
     notes: '',
     notesModifyTime: surveyTimestamp, // Can't use serverTimestamp in arrays...
+    submissionTime: surveyTimestamp,
   }))
 
   // First, update the [student] collection to include the data for the new student
@@ -152,7 +153,6 @@ export const addStudentSurveyResponse = async (
       college,
       year,
       groups: [...existingCourses, ...newCourses],
-      submissionTime: surveyTimestamp,
     })
     .catch((err) => {
       console.log(err)

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -1,3 +1,7 @@
+import admin from 'firebase-admin'
+
+type Timestamp = admin.firestore.Timestamp
+
 // For now this exists in the backend folder only
 // Future: become a cool monorepo and have shared types backend/frontend
 
@@ -8,7 +12,6 @@ export type Student = {
   email: string
   college: string
   year: string
-  submissionTime: Date
   groups: GroupMembership[]
 }
 
@@ -18,4 +21,22 @@ export type GroupMembership = {
   groupNumber: number
   notes: string
   notesModifyTime: Date
+  submissionTime: Date
+}
+
+/** How student data is stored in the database */
+export type FirestoreStudent = {
+  name: string
+  college: string
+  year: string
+  groups: FirestoreGroupMembership[]
+}
+
+/** How group membership for students is stored in the database */
+export type FirestoreGroupMembership = {
+  courseId: string
+  groupNumber: number
+  notes: string
+  notesModifyTime: Timestamp
+  submissionTime: Timestamp
 }

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import axios, { AxiosResponse } from 'axios'
 import GroupCard from 'EditZing/Components/GroupCard'
 import { UnmatchedGrid } from './UnmatchedGrid'
-import { Student } from 'EditZing/Types/Student'
+import { responseStudentToStudent, Student } from 'EditZing/Types/Student'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import {
@@ -10,6 +10,7 @@ import {
   CourseInfoResponse,
   CourseStudentDataResponse,
   Group,
+  ResponseGroup,
 } from 'EditZing/Types/CourseInfo'
 import { API_ROOT, COURSE_API, MATCHING_API } from '@core/Constants'
 import { useParams } from 'react-router-dom'
@@ -94,18 +95,12 @@ export const EditZing = () => {
       .get(`${API_ROOT}${COURSE_API}/students/${courseId}`)
       .then((res: AxiosResponse<CourseStudentDataResponse>) => {
         setUnmatchedStudents(
-          res.data.data.unmatched.map((student) => ({
-            ...student,
-            submissionTime: new Date(student.submissionTime),
-          }))
+          res.data.data.unmatched.map(responseStudentToStudent)
         )
         setStudentGroups(
           res.data.data.groups.map((group) => ({
             ...group,
-            memberData: group.memberData.map((student) => ({
-              ...student,
-              submissionTime: new Date(student.submissionTime),
-            })),
+            memberData: group.memberData.map(responseStudentToStudent),
             createTime: new Date(group.createTime),
             updateTime: new Date(group.updateTime),
             shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
@@ -236,18 +231,12 @@ export const EditZing = () => {
       .post(`${API_ROOT}${MATCHING_API}/make`, { courseId: courseId })
       .then((response) => {
         setUnmatchedStudents(
-          response.data.data.unmatched.map((student: any) => ({
-            ...student,
-            submissionTime: new Date(student.submissionTime),
-          }))
+          response.data.data.unmatched.map(responseStudentToStudent)
         )
         const groups = studentGroups.concat(
-          response.data.data.groups.map((group: Group) => ({
+          response.data.data.groups.map((group: ResponseGroup) => ({
             ...group,
-            memberData: group.memberData.map((student) => ({
-              ...student,
-              submissionTime: new Date(student.submissionTime),
-            })),
+            memberData: group.memberData.map(responseStudentToStudent),
             createTime: new Date(group.createTime),
             updateTime: new Date(group.updateTime),
             shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
@@ -273,18 +262,12 @@ export const EditZing = () => {
       .get(`${API_ROOT}${COURSE_API}/students/${courseId}`)
       .then((res: AxiosResponse<CourseStudentDataResponse>) => {
         setUnmatchedStudents(
-          res.data.data.unmatched.map((student) => ({
-            ...student,
-            submissionTime: new Date(student.submissionTime),
-          }))
+          res.data.data.unmatched.map(responseStudentToStudent)
         )
         setStudentGroups(
           res.data.data.groups.map((group) => ({
             ...group,
-            memberData: group.memberData.map((student) => ({
-              ...student,
-              submissionTime: new Date(student.submissionTime),
-            })),
+            memberData: group.memberData.map(responseStudentToStudent),
             createTime: new Date(group.createTime),
             updateTime: new Date(group.updateTime),
             shareMatchEmailTimestamp: group.shareMatchEmailTimestamp
@@ -430,6 +413,7 @@ export const EditZing = () => {
           >
             <Box sx={{ gridColumn: '1 / -1' }}>
               <UnmatchedGrid
+                courseId={courseId}
                 unmatchedStudents={unmatchedStudents}
                 moveStudent={moveStudent}
                 matchStudents={matchStudents}
@@ -439,6 +423,7 @@ export const EditZing = () => {
             {studentGroups.map((studentGroup, index) => (
               <GroupCard
                 key={studentGroup.groupNumber}
+                courseId={courseId}
                 studentList={studentGroup.memberData}
                 groupNumber={studentGroup.groupNumber}
                 shareMatchEmailTimestamp={studentGroup.shareMatchEmailTimestamp}

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -9,6 +9,7 @@ import CircleIcon from '@mui/icons-material/Circle'
 
 /** the equivalent of Column */
 const GroupCard = ({
+  courseId,
   studentList,
   groupNumber,
   moveStudent,
@@ -136,9 +137,9 @@ const GroupCard = ({
           {studentList.map((student, index) => (
             <StudentCard
               key={index}
+              courseId={courseId}
               groupNumber={groupNumber}
               student={student}
-              submissionTime={student.submissionTime}
               handleAddStudent={handleAddStudent}
             />
           ))}

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -8,10 +8,10 @@ import { Checkbox, Box, Typography } from '@mui/material'
 
 /** the equivalent of MoveableItem */
 const StudentCard = ({
+  courseId,
   student,
   groupNumber,
   xsSize = 6,
-  submissionTime,
   handleAddStudent,
 }: StudentGridProps) => {
   const [{ isDragging }, drag] = useDrag({
@@ -34,6 +34,10 @@ const StudentCard = ({
   }
 
   const opacity = isDragging ? '0' : '1.0'
+
+  const submissionTime = student.groups.find(
+    (groupMembership) => groupMembership.courseId === courseId
+  )!.submissionTime
 
   return (
     <Box

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -13,6 +13,7 @@ import { MatchButton } from './MatchButton'
 
 /** Where unmatched students live in the grid */
 export const UnmatchedGrid = ({
+  courseId,
   unmatchedStudents,
   moveStudent,
   matchStudents,
@@ -45,10 +46,10 @@ export const UnmatchedGrid = ({
           {unmatchedStudents.map((student, index) => (
             <StudentCard
               key={index}
+              courseId={courseId}
               groupNumber={-1}
               student={student}
               xsSize={xsSize}
-              submissionTime={student.submissionTime}
               handleAddStudent={handleAddStudent}
             />
           ))}

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -4,6 +4,7 @@ import { Group } from './CourseInfo'
 import { TemplateName } from 'EditZing/utils/emailTemplates'
 
 export interface UnmatchedGridProps {
+  courseId: string
   unmatchedStudents: Student[]
   moveStudent: (
     studentToMove: Student,
@@ -15,6 +16,7 @@ export interface UnmatchedGridProps {
 }
 
 export interface GroupGridProps {
+  courseId: string
   studentList: Student[]
   groupNumber: number
   shareMatchEmailTimestamp: Date | null
@@ -33,10 +35,10 @@ export interface GroupGridProps {
 }
 
 export interface StudentGridProps {
+  courseId: string
   student: Student
   groupNumber: number
   xsSize?: GridSize
-  submissionTime: Date
   handleAddStudent: (student: string, selected: boolean) => void
 }
 

--- a/frontend/src/modules/EditZing/Types/CourseInfo.ts
+++ b/frontend/src/modules/EditZing/Types/CourseInfo.ts
@@ -1,4 +1,4 @@
-import { Student } from './Student'
+import { ResponseStudent, Student } from './Student'
 
 // This interface does not contain all of the fields that are returned
 export interface CourseInfo {
@@ -7,7 +7,7 @@ export interface CourseInfo {
   unmatched: string[]
 }
 
-export type Group = {
+export interface Group {
   groupNumber: number
   memberData: Student[]
   createTime: Date
@@ -15,6 +15,16 @@ export type Group = {
   shareMatchEmailTimestamp: Date | null
   checkInEmailTimestamp: Date | null
   addStudentEmailTimestamp: Date | null
+}
+
+export interface ResponseGroup {
+  groupNumber: number
+  memberData: ResponseStudent[]
+  createTime: string
+  updateTime: string
+  shareMatchEmailTimestamp: string | null
+  checkInEmailTimestamp: string | null
+  addStudentEmailTimestamp: string | null
 }
 
 export interface CourseInfoResponse {
@@ -25,7 +35,7 @@ export interface CourseInfoResponse {
 export interface CourseStudentDataResponse {
   success: boolean
   data: {
-    unmatched: Student[]
-    groups: Group[]
+    unmatched: ResponseStudent[]
+    groups: ResponseGroup[]
   }
 }

--- a/frontend/src/modules/EditZing/Types/Student.ts
+++ b/frontend/src/modules/EditZing/Types/Student.ts
@@ -1,15 +1,31 @@
-export type Student = {
+export interface Student {
   name: string
   email: string
   year: string
   college: string
-  submissionTime: Date
   groups: GroupMembership[]
 }
 
-export type GroupMembership = {
+export interface GroupMembership {
   courseId: string
   groupNumber: number
+  submissionTime: Date
+}
+
+export interface ResponseStudent {
+  name: string
+  email: string
+  year: string
+  college: string
+  groups: ResponseGroupMembership[]
+}
+
+export interface ResponseGroupMembership {
+  courseId: string
+  groupNumber: number
+  notes: string
+  notesModifyTime: string
+  submissionTime: string
 }
 
 /** item type for drag and drop prop transfer via dnd */
@@ -23,3 +39,14 @@ export type DnDStudentTransferType = {
  * this case, this is a movable student type
  */
 export const STUDENT_TYPE = 'Student'
+
+export const responseStudentToStudent = (
+  student: ResponseStudent
+): Student => ({
+  ...student,
+  groups: student.groups.map((groupMembership) => ({
+    ...groupMembership,
+    // Remember to convert the notesModifyTime too
+    submissionTime: new Date(groupMembership.submissionTime),
+  })),
+})


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request modifies the survey timestamp to be tracked per class of a universal submission time for all classes the student is in.

This is beneficial because it allows for greater detail how many times the student submitted the survey, e.g. did they submit both classes at once or did they submit the survey for a class and come back a week later to submit for the other class. It is especially important for usage across semesters because if a return student submitted a new survey, the submission timestamp for the previous semester would be wiped out. This PR prevents that by tracking the survey timestamp on a per-class basis.

Also included are improvements to type definitions for both the frontend (`ResponseStudent` and similar) and the backend (`FirestoreStudent` and similar). Types that start with `Response` are intended to represent what data the backend sends to the frontend. Dates are sent as strings and converted into Date objects on the frontend. Types that start with `Firestore` represent what data is actually stored in the database. Types without prefix are the types meant to be used normally. Factored out some code to convert `ResponseStudent` to `Student` on the frontend.

- [x] implemented tracking survey timestamp per class on backend and frontend
- [x] lots of new types to more accurately show what's going on

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Example response in Insomnia. Tested submitting the survey multiple times and confirmed different timestamps were recorded. Submitting the same class in a future survey does not affect the original timestamp. Also tested new types in the app to verify they work correctly.

<img width="372" alt="Screen Shot 2022-07-09 at 19 31 01" src="https://user-images.githubusercontent.com/22627336/178128945-9ba663fd-1985-4223-9579-79fcefa6cf15.png">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

Typed some things, but not everything. Mainly updated in the functions that I am most familiar with, there may be other places the types could be incorporated.

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
`submissionTime` is stored for each element of the student's `groups` array instead of in each student document at the top level.

When this PR is about to be merged I will write a script to convert the staging and production databases to match the expected structure.