### PR TITLE
Emailing Individuals Backend

### DIFF
--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -6,7 +6,7 @@ import { logger } from 'firebase-functions'
 import { db } from '../config'
 const courseRef = db.collection('courses')
 const studentRef = db.collection('students')
-import { FirestoreGroupMembership, FirestoreStudent } from '../types'
+import { FirestoreStudent } from '../types'
 
 // ==== Timestamp helper functions
 

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -241,10 +241,13 @@ export const sendStudEmails = async (
   template = 'Share matched results',
   indivEmail?: string
 ) => {
-  const emailRcpts = await getRecipients(courseId, group, indivEmail)
+  let emailRcpts: string[]
+
+  emailRcpts = await getRecipients(courseId, group, indivEmail)
+
   const message = createEmailAsJson(emailRcpts, subject, body)
 
-  return await sendMails(
+  await sendMails(
     from,
     message,
     authToken,
@@ -253,4 +256,24 @@ export const sendStudEmails = async (
     template,
     indivEmail
   )
+    .then((result) => {
+      if (result === 202) {
+        logger.info(
+          `Email sent successfully by ${from} to ${emailRcpts.toString()}`
+        )
+      } else {
+        logger.error(
+          `** Likely auth error ** : Email failed to send by ${from} to ${emailRcpts.toString()}`
+        )
+
+        throw Error('Email send failure')
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        `Email send request failed from ${from} to ${emailRcpts.toString()}`
+      )
+
+      throw err
+    })
 }

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -201,12 +201,12 @@ export const sendMails = async (
         await updateEmailTimestamp(courseId, group, template)
           .then(() =>
             logger.info(
-              `Added timestamp for course ${courseId} for group ${group} with template "${template}"`
+              `Added timestamp for course ${courseId} for group ${group} with template ${template}`
             )
           )
           .catch((err) =>
             logger.error(
-              `Failed to update timestamp for course ${courseId} for group ${group} with template "${template}." Resulted in err: ${err.message} `
+              `Failed to update timestamp for course ${courseId} for group ${group} with template ${template}. Resulted in err: ${err.message} `
             )
           )
       }

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -79,7 +79,7 @@ export async function getRecipients(
   let emailRcpts = ['lscstudypartners@cornell.edu']
 
   if (group && indivEmail) {
-    throw new Error('Both group and indivEmail are specified')
+    throw new Error('group and indivEmail cannot both be specified')
   }
 
   if (group && parseInt(group) > 0) {
@@ -176,7 +176,7 @@ export const sendMails = async (
 ) => {
   if ((!group || parseInt(group) < 0) && !indivEmail) {
     logger.error(
-      ` Invalid group ${group} and invalid email "${indivEmail}" for updating timestamps `
+      ` Invalid group ${group} and invalid email ${indivEmail} for updating timestamps `
     )
     throw new Error('No valid group or individual email')
   } else if (group && indivEmail) {
@@ -241,9 +241,7 @@ export const sendStudEmails = async (
   template = 'Share matched results',
   indivEmail?: string
 ) => {
-  let emailRcpts: string[]
-
-  emailRcpts = await getRecipients(courseId, group, indivEmail)
+  const emailRcpts = await getRecipients(courseId, group, indivEmail)
 
   const message = createEmailAsJson(emailRcpts, subject, body)
 

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -4,9 +4,10 @@ import axios from 'axios'
 import admin from 'firebase-admin'
 import { logger } from 'firebase-functions'
 import { db } from '../config'
+import { FirestoreStudent } from '../types'
+
 const courseRef = db.collection('courses')
 const studentRef = db.collection('students')
-import { FirestoreStudent } from '../types'
 
 // ==== Timestamp helper functions
 

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -1,4 +1,4 @@
-//import axios from 'axios'
+import axios from 'axios'
 
 // firebase imports
 import admin from 'firebase-admin'
@@ -62,16 +62,13 @@ export const updateIndivTimestamp = async (courseId: string, email: string) => {
     throw new Error(`Student ${email} does not have membership in ${courseId}`)
   }
 
-  groupMembership.firstNoMatchEmailTimestamp = admin.firestore.Timestamp.now()
+  groupMembership.firstNoMatchEmailTime = admin.firestore.Timestamp.now()
 
   await studentDocRef.update({ groups })
-  logger.info(
-    `Updated email timestamp for first no match email for student [${email}] in [${courseId}]`
-  )
 }
 
 /* ==== Emailing Helper Functions ==== */
-//const GRAPH_ENDPOINT = 'https://graph.microsoft.com'
+const GRAPH_ENDPOINT = 'https://graph.microsoft.com'
 
 /* Add Recipients parses frontend data and adds to 
     the 'toRecipients' key-value pair of 
@@ -149,7 +146,7 @@ export const sendMails = async (
   indivEmail?: string
 ) => {
   try {
-    /*const response = await axios({
+    const response = await axios({
       url: `${GRAPH_ENDPOINT}/v1.0/users/${from}/sendMail`,
       // url: 'https://graph.microsoft.com/v1.0/users/wz282@cornell.edu/sendMail',
       method: 'POST',
@@ -158,9 +155,8 @@ export const sendMails = async (
         'Content-Type': 'application/json',
       },
       data: JSON.stringify(message),
-    }) */
+    })
 
-    const response = { status: 202 }
     if (response.status === 202) {
       if (parseInt(group) > 0) {
         await updateEmailTimestamp(courseId, group, template)
@@ -174,7 +170,9 @@ export const sendMails = async (
               `Failed to update timestamp for course ${courseId} for group ${group} with template ${template}. Resulted in err: ${err.message} `
             )
           )
-      } else if (typeof indivEmail !== 'undefined') {
+      }
+
+      if (typeof indivEmail !== 'undefined') {
         await updateIndivTimestamp(courseId, indivEmail)
           .then(() =>
             logger.info(
@@ -186,7 +184,9 @@ export const sendMails = async (
               `Failed to update no match timestamp for course ${courseId} for student with email ${indivEmail}. Resulted in err: ${err.message} `
             )
           )
-      } else {
+      }
+
+      if (parseInt(group) < 0 && typeof indivEmail === undefined) {
         logger.error(
           ` Invalid group ${group} and invalid email ${indivEmail} for updating timestamps `
         )

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -174,6 +174,7 @@ export const sendMails = async (
   template = 'Share matched results',
   indivEmail?: string
 ) => {
+  //not sure if this check is necessary, since emailRcpts already checks for this
   if ((!group || parseInt(group) < 0) && !indivEmail) {
     logger.error(
       ` Invalid group ${group} and invalid email ${indivEmail} for updating timestamps `
@@ -231,7 +232,7 @@ export const sendMails = async (
   }
 }
 
-export const sendStudEmails = async (
+export const sendStudentEmails = async (
   from: string,
   authToken: string,
   subject: string,
@@ -242,7 +243,6 @@ export const sendStudEmails = async (
   indivEmail?: string
 ) => {
   const emailRcpts = await getRecipients(courseId, group, indivEmail)
-
   const message = createEmailAsJson(emailRcpts, subject, body)
 
   await sendMails(

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -166,16 +166,16 @@ export const sendMails = async (
   message: any,
   authToken: string,
   courseId: string,
-  group = '-1',
+  group?: string,
   template = 'Share matched results',
   indivEmail?: string
 ) => {
-  if (parseInt(group) < 0 && indivEmail === undefined) {
+  if (!group || (parseInt(group) < 0 && indivEmail === undefined)) {
     logger.error(
       ` Invalid group ${group} and invalid email "${indivEmail}" for updating timestamps `
     )
     return
-  } else if (parseInt(group) > 0 && indivEmail !== undefined) {
+  } else if (group && indivEmail) {
     logger.error(`group and individual email cannot both be specified `)
     return
   }
@@ -193,7 +193,7 @@ export const sendMails = async (
     })
 
     if (response.status === 202) {
-      if (parseInt(group) > 0) {
+      if (group && parseInt(group) > 0) {
         await updateEmailTimestamp(courseId, group, template)
           .then(() =>
             logger.info(

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -47,16 +47,9 @@ export const updateEmailTimestamp = (
     .update({ [timestampField]: time })
 }
 
-export const updateIndivTimestamp = async (
-  courseId: string,
-  email: string,
-  template: string
-) => {
+export const updateIndivTimestamp = async (courseId: string, email: string) => {
   const studentDocRef = studentRef.doc(email)
   const studentDoc = await studentDocRef.get()
-  const timestampField = getTimestampField(
-    template
-  ) as keyof FirestoreGroupMembership
 
   if (!studentDoc.exists) {
     throw new Error(`Student document for ${email} does not exist`)
@@ -69,12 +62,11 @@ export const updateIndivTimestamp = async (
     throw new Error(`Student ${email} does not have membership in ${courseId}`)
   }
 
-  let timefield = groupMembership[timestampField] as admin.firestore.Timestamp
-  timefield = admin.firestore.Timestamp.now()
+  groupMembership.firstNoMatchEmailTimestamp = admin.firestore.Timestamp.now()
 
   await studentDocRef.update({ groups })
   logger.info(
-    `Updated email timestamp for template [${template}] for student [${email}] in [${courseId}]`
+    `Updated email timestamp for first no match email for student [${email}] in [${courseId}]`
   )
 }
 

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -5,7 +5,7 @@ import {
   createEmailAsJson,
   sendMails,
   updateEmailTimestamp,
-  updateIndivTimestamp,
+  //updateIndivTimestamp,
 } from './functions'
 
 const router = express()
@@ -37,7 +37,6 @@ router.post('/send', async (req, res) => {
     authToken,
     emailBody,
     emailSubject,
-    emailRcpts,
     courseId,
     group,
     template,
@@ -48,9 +47,13 @@ router.post('/send', async (req, res) => {
     .collection('groups')
     .doc(group)
     .get()
-  const groupRcpts = (groupData.data() as any).members
 
-  const message = createEmailAsJson(groupRcpts, emailSubject, emailBody)
+  const emailRcpts = [
+    'lscstudypartners@cornell.edu',
+    ...(groupData.data() as any).members,
+  ]
+
+  const message = createEmailAsJson(emailRcpts, emailSubject, emailBody)
 
   sendMails(emailAddress, message, authToken, courseId, group, template)
     .then((result) => {

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -52,11 +52,11 @@ router.post('/send', async (req, res) => {
       .doc(group)
       .get()
 
-    emailRcpts = [emailRcpts, ...(groupData.data() as any).members]
+    emailRcpts = [...emailRcpts, ...(groupData.data() as any).members]
   }
 
   if (indivEmail !== undefined) {
-    emailRcpts = [emailRcpts, ...indivEmail]
+    emailRcpts = [...emailRcpts, indivEmail]
   }
 
   const message = createEmailAsJson(emailRcpts, emailSubject, emailBody)

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -43,7 +43,7 @@ router.post('/send', async (req, res) => {
     indivEmail,
   } = req.body
 
-  let emailRcpts: string[] = []
+  let emailRcpts = ['lscstudypartners@cornell.edu']
 
   if (parseInt(group) > 0) {
     const groupData = await courseRef
@@ -52,12 +52,11 @@ router.post('/send', async (req, res) => {
       .doc(group)
       .get()
 
-    emailRcpts = [
-      'lscstudypartners@cornell.edu',
-      ...(groupData.data() as any).members,
-    ]
-  } else {
-    emailRcpts = [indivEmail]
+    emailRcpts = [emailRcpts, ...(groupData.data() as any).members]
+  }
+
+  if (indivEmail !== undefined) {
+    emailRcpts = [emailRcpts, ...indivEmail]
   }
 
   const message = createEmailAsJson(emailRcpts, emailSubject, emailBody)

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -40,7 +40,16 @@ router.post('/send', async (req, res) => {
     indivEmail,
   } = req.body
 
-  const emailRcpts = await getRecipients(courseId, group, indivEmail)
+  let emailRcpts: string[]
+
+  //This is not a great solution, but I don't know a better way to log the email recipients
+  try {
+    emailRcpts = await getRecipients(courseId, group, indivEmail)
+  } catch (err: any) {
+    logger.error(err.message)
+    res.status(400).json('invalid email recipients')
+    return
+  }
 
   sendStudEmails(
     emailAddress,
@@ -69,7 +78,7 @@ router.post('/send', async (req, res) => {
       logger.error(
         `Email send request failed from ${emailAddress} to ${emailRcpts.toString()}`
       )
-      res.status(400)
+      res.sendStatus(400)
     })
 })
 

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -47,7 +47,7 @@ router.post('/send', async (req, res) => {
     emailRcpts = await getRecipients(courseId, group, indivEmail)
   } catch (err: any) {
     logger.error(err.message)
-    res.status(400).json('invalid email recipients')
+    res.status(400).send({ success: false, message: err.message })
     return
   }
 
@@ -74,11 +74,11 @@ router.post('/send', async (req, res) => {
         res.status(400).json('Email send failure.')
       }
     })
-    .catch(() => {
+    .catch((err) => {
       logger.error(
         `Email send request failed from ${emailAddress} to ${emailRcpts.toString()}`
       )
-      res.sendStatus(400)
+      res.status(400).send({ success: false, message: err.message })
     })
 })
 

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { logger } from 'firebase-functions'
-import { sendStudEmails, updateEmailTimestamp } from './functions'
+import { sendStudentEmails, updateEmailTimestamp } from './functions'
 
 const router = express()
 
@@ -24,7 +24,7 @@ const router = express()
       FAIL -> res.data = 'Email send failure.' 
 
     */
-router.post('/send', async (req, res) => {
+router.post('/send', (req, res) => {
   const {
     emailAddress,
     authToken,
@@ -36,22 +36,22 @@ router.post('/send', async (req, res) => {
     indivEmail,
   } = req.body
 
-  try {
-    await sendStudEmails(
-      emailAddress,
-      authToken,
-      emailSubject,
-      emailBody,
-      courseId,
-      group,
-      template,
-      indivEmail
+  sendStudentEmails(
+    emailAddress,
+    authToken,
+    emailSubject,
+    emailBody,
+    courseId,
+    group,
+    template,
+    indivEmail
+  )
+    .then(() =>
+      res.status(200).json({ success: true, message: 'Email send success' })
     )
-
-    res.status(200).json('Email send success')
-  } catch (err: any) {
-    res.status(400).json(err.message)
-  }
+    .catch((err) =>
+      res.status(400).json({ success: false, message: err.message })
+    )
 })
 
 /** @.com/api root/email/timestamp

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -1,8 +1,7 @@
 import express from 'express'
 import { logger } from 'firebase-functions'
 import {
-  createEmailAsJson,
-  sendMails,
+  sendStudEmails,
   updateEmailTimestamp,
   getRecipients,
 } from './functions'
@@ -33,8 +32,8 @@ router.post('/send', async (req, res) => {
   const {
     emailAddress,
     authToken,
-    emailBody,
     emailSubject,
+    emailBody,
     courseId,
     group,
     template,
@@ -42,12 +41,12 @@ router.post('/send', async (req, res) => {
   } = req.body
 
   const emailRcpts = await getRecipients(courseId, group, indivEmail)
-  const message = createEmailAsJson(emailRcpts, emailSubject, emailBody)
 
-  sendMails(
+  sendStudEmails(
     emailAddress,
-    message,
     authToken,
+    emailSubject,
+    emailBody,
     courseId,
     group,
     template,
@@ -58,19 +57,20 @@ router.post('/send', async (req, res) => {
         logger.info(
           `Email sent successfully by ${emailAddress} to ${emailRcpts.toString()}`
         )
-        res.json('Email send success.')
+        res.status(200).json('Email send success.')
       } else {
         logger.error(
           `** Likely auth error ** : Email failed to send by ${emailAddress} to ${emailRcpts.toString()}`
         )
-        res.json('Email send failure.')
+        res.status(400).json('Email send failure.')
       }
     })
-    .catch(() =>
+    .catch(() => {
       logger.error(
         `Email send request failed from ${emailAddress} to ${emailRcpts.toString()}`
       )
-    )
+      res.status(400)
+    })
 })
 
 /** @.com/api root/email/timestamp

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -40,22 +40,37 @@ router.post('/send', async (req, res) => {
     courseId,
     group,
     template,
+    indivEmail,
   } = req.body
 
-  const groupData = await courseRef
-    .doc(courseId)
-    .collection('groups')
-    .doc(group)
-    .get()
+  let emailRcpts: string[] = []
 
-  const emailRcpts = [
-    'lscstudypartners@cornell.edu',
-    ...(groupData.data() as any).members,
-  ]
+  if (parseInt(group) > 0) {
+    const groupData = await courseRef
+      .doc(courseId)
+      .collection('groups')
+      .doc(group)
+      .get()
+
+    emailRcpts = [
+      'lscstudypartners@cornell.edu',
+      ...(groupData.data() as any).members,
+    ]
+  } else {
+    emailRcpts = [indivEmail]
+  }
 
   const message = createEmailAsJson(emailRcpts, emailSubject, emailBody)
 
-  sendMails(emailAddress, message, authToken, courseId, group, template)
+  sendMails(
+    emailAddress,
+    message,
+    authToken,
+    courseId,
+    group,
+    template,
+    indivEmail
+  )
     .then((result) => {
       if (result === 202) {
         logger.info(

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -1,6 +1,11 @@
 import express from 'express'
 import { logger } from 'firebase-functions'
-import { createEmailAsJson, sendMails, updateEmailTimestamp } from './functions'
+import {
+  createEmailAsJson,
+  sendMails,
+  updateEmailTimestamp,
+  updateIndivTimestamp,
+} from './functions'
 
 const router = express()
 
@@ -81,6 +86,11 @@ router.post('/timestamp', (req, res) => {
       )
       res.status(400).json('ERROR: email Time update failure')
     })
+})
+
+router.post('/indiv-timestamp', (req, res) => {
+  const { courseId, email, template } = req.body
+  updateIndivTimestamp(courseId, email, template)
 })
 
 export default router

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -1,12 +1,7 @@
 import express from 'express'
 import { logger } from 'firebase-functions'
 import { db } from '../config'
-import {
-  createEmailAsJson,
-  sendMails,
-  updateEmailTimestamp,
-  //updateIndivTimestamp,
-} from './functions'
+import { createEmailAsJson, sendMails, updateEmailTimestamp } from './functions'
 
 const router = express()
 const courseRef = db.collection('courses')

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -39,11 +39,5 @@ export type FirestoreGroupMembership = {
   notes: string
   notesModifyTime: Timestamp
   submissionTime: Timestamp
-  shareMatchEmailTimestamp?: Timestamp
-  firstNoMatchEmailTimestamp?: Timestamp
-  secondNoMatchEmailTimestamp?: Timestamp
-  addStudentEmailTimestamp?: Timestamp
-  lateAddStudentEmailTimestamp?: Timestamp
-  askJoinGroupEmailTimestamp?: Timestamp
-  checkInEmailTimestamp?: Timestamp
+  firstNoMatchEmailTimestamp: Timestamp
 }

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -39,4 +39,11 @@ export type FirestoreGroupMembership = {
   notes: string
   notesModifyTime: Timestamp
   submissionTime: Timestamp
+  shareMatchEmailTimestamp?: Timestamp
+  firstNoMatchEmailTimestamp?: Timestamp
+  secondNoMatchEmailTimestamp?: Timestamp
+  addStudentEmailTimestamp?: Timestamp
+  lateAddStudentEmailTimestamp?: Timestamp
+  askJoinGroupEmailTimestamp?: Timestamp
+  checkInEmailTimestamp?: Timestamp
 }

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -39,5 +39,5 @@ export type FirestoreGroupMembership = {
   notes: string
   notesModifyTime: Timestamp
   submissionTime: Timestamp
-  firstNoMatchEmailTimestamp: Timestamp
+  firstNoMatchEmailTime: Timestamp
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request modifies the `email/send` API endpoint to accommodate sending "no match" emails to individual students. This entails allowing requests to the endpoint to specify an individual recipient in lieu of a group, and updating the email send timestamp for an individual student after the email has been sent.

- [x] added functionality to send individual emails to `email/send` endpoint
- [x] added location in the Firestore database to log timestamps for emails sent to individual students
- [x] `email/send` endpoint now infers email recipients based on group number instead of having requests explicitly define the recipients

### Test Plan <!-- Required -->

Test data was obtained by running `npm run populate.` Testing was conducted by submitting requests to email individual students using Insomnia, looking at backend logs, and verifying that the Firestore database was updated with the correct timestamps.

<!-- Provide screenshots or point out the additional unit tests -->

Sample request using Insomnia
<img width="552" alt="Screen Shot 2022-07-18 at 12 25 21 PM" src="https://user-images.githubusercontent.com/45516888/179562133-6b855996-bdad-496f-8c23-587d09bed4ac.png">

Backend logs verify emails were sent and timestamps were updated
<img width="885" alt="Screen Shot 2022-07-18 at 12 26 34 PM" src="https://user-images.githubusercontent.com/45516888/179562148-47657eb2-6dd6-4d55-840d-a8f4a1c0a480.png">

Timestamp for "no match" email updated in Firestore database
<img width="1255" alt="Screen Shot 2022-07-18 at 12 28 09 PM" src="https://user-images.githubusercontent.com/45516888/179562161-923f98f1-fa7e-4ea6-be8c-e86861b86ae5.png">


### Notes <!-- Optional -->

- since updating timestamps occurs after an email is already sent, there is the possibility that an email will be sent to a student but the student's timestamp will not be updated. This should only occur in the rare case where an email is sent to an individual who does not belong to the course specified in the request.

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
- added a `firstNoMatchEmailTime` field to the groups array within the students collection in the Firestore database