### PR TITLE
Template editor add/update templates

### DIFF
--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -312,7 +312,7 @@ const assertValidEmailType = (type: string) => {
 }
 
 /** Update an email template with new name, type, and subject */
-export const updateEmailTemplate = (
+export const updateEmailTemplate = async (
   id: string,
   name: string,
   type: 'group' | 'student',
@@ -346,7 +346,7 @@ export const updateEmailTemplate = (
  * Add a new email template with name, type, and subject.
  * @returns id of the newly created template
  */
-export const addEmailTemplate = (
+export const addEmailTemplate = async (
   name: string,
   type: 'group' | 'student',
   subject: string
@@ -367,9 +367,5 @@ export const addEmailTemplate = (
         `Added new email template ${templateDoc.id} with name ${name}, type ${type}, subject ${subject}`
       )
       return templateDoc.id
-    })
-    .catch((err) => {
-      logger.error(`Unexpected error adding email template: ${err}`)
-      throw err
     })
 }

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -294,3 +294,39 @@ export const getEmailTemplates = async () => {
         } as EmailTemplate)
     )
 }
+
+/** Update an email template with new name, type, and subject */
+export const updateEmailTemplate = (
+  id: string,
+  name: string,
+  type: 'group' | 'student',
+  subject: string
+) => {
+  const types = ['group', 'student']
+  if (!types.includes(type)) {
+    logger.error(`Email type ${type} is not in types [${types.join(', ')}]`)
+    throw new Error(`Unrecognized email type ${type}`)
+  }
+
+  return templateRef
+    .doc(id)
+    .update({
+      name,
+      type,
+      subject,
+      modifyTime: admin.firestore.Timestamp.now(),
+    })
+    .then(() =>
+      logger.info(
+        `Updated email template ${id} with name ${name}, type ${type}, subject ${subject}`
+      )
+    )
+    .catch((err) => {
+      if (err.message.includes('NOT_FOUND')) {
+        logger.error(`Cannot update nonexistent template id ${id}`)
+        throw new Error(`No email template with id ${id}`)
+      } else {
+        throw err
+      }
+    })
+}

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -3,6 +3,7 @@ import { logger } from 'firebase-functions'
 import {
   getEmailTemplates,
   sendStudentEmails,
+  updateEmailTemplate,
   updateEmailTimestamp,
 } from './functions'
 
@@ -90,6 +91,20 @@ router.get('/templates', (req, res) => {
     .catch((err) => {
       logger.error(`Unexpected error getting email templates: ${err.message}`)
       res.status(500).send({ success: false, err: err.message })
+    })
+})
+
+router.post('/templates/update', (req, res) => {
+  const { id, name, type, subject } = req.body
+  updateEmailTemplate(id, name, type, subject)
+    .then(() => res.status(200).send({ success: true }))
+    .catch((err) => {
+      const code =
+        err.message.includes('Unrecognized email type') ||
+        err.message.includes('No email template with id')
+          ? 400
+          : 500
+      res.status(code).send({ success: false, err: err.message })
     })
 })
 

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -90,7 +90,7 @@ router.get('/templates', (req, res) => {
   getEmailTemplates()
     .then((data) => res.status(200).send({ success: true, data }))
     .catch((err) => {
-      logger.error(`Unexpected error getting email templates: ${err.message}`)
+      logger.error(`Error getting email templates: ${err.message}`)
       res.status(500).send({ success: false, err: err.message })
     })
 })
@@ -106,6 +106,9 @@ router.post('/templates/update', (req, res) => {
         err.message.includes('No email template with id')
           ? 400
           : 500
+      if (code !== 400) {
+        logger.error(`Error updating email template ${id}: ${err.message}`)
+      }
       res.status(code).send({ success: false, err: err.message })
     })
 })
@@ -117,6 +120,9 @@ router.post('/templates/add', (req, res) => {
     .then((id) => res.status(200).send({ success: true, data: id }))
     .catch((err) => {
       const code = err.message.includes('Unrecognized email type') ? 400 : 500
+      if (code !== 400) {
+        logger.error(`Error adding email template ${err.message}`)
+      }
       res.status(code).send({ success: false, err: err.message })
     })
 })

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import { logger } from 'firebase-functions'
 import {
+  addEmailTemplate,
   getEmailTemplates,
   sendStudentEmails,
   updateEmailTemplate,
@@ -105,6 +106,17 @@ router.post('/templates/update', (req, res) => {
         err.message.includes('No email template with id')
           ? 400
           : 500
+      res.status(code).send({ success: false, err: err.message })
+    })
+})
+
+/** Add a new template and get its automatically generated id */
+router.post('/templates/add', (req, res) => {
+  const { name, type, subject } = req.body
+  addEmailTemplate(name, type, subject)
+    .then((id) => res.status(200).send({ success: true, data: id }))
+    .catch((err) => {
+      const code = err.message.includes('Unrecognized email type') ? 400 : 500
       res.status(code).send({ success: false, err: err.message })
     })
 })

--- a/backend/functions/src/emailing/routes.ts
+++ b/backend/functions/src/emailing/routes.ts
@@ -94,6 +94,7 @@ router.get('/templates', (req, res) => {
     })
 })
 
+/** Update information for an already existing email template */
 router.post('/templates/update', (req, res) => {
   const { id, name, type, subject } = req.body
   updateEmailTemplate(id, name, type, subject)

--- a/frontend/src/modules/TemplateEditor/Components/TemplateEditor.tsx
+++ b/frontend/src/modules/TemplateEditor/Components/TemplateEditor.tsx
@@ -127,9 +127,9 @@ export const TemplateEditor = () => {
         type: templateType,
         subject: templateSubject,
       })
-      .then((response) => {
+      .then(async (response) => {
         const id = response.data.data as string
-        uploadString(
+        await uploadString(
           ref(
             templatesBucket,
             `${id}.html` // body is id.html the new template was created with
@@ -179,7 +179,7 @@ export const TemplateEditor = () => {
       <Typography variant="h4" component="h1" mb={4}>
         Template Editor
       </Typography>
-      <Box component="main" display="flex" gap={4}>
+      <Box component="main" display="flex" alignItems="flex-start" gap={4}>
         <List sx={{ minWidth: 400 }}>
           <ListItemButton
             selected={isAddingTemplate}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the ability to create new templates and save changes to existing templates to the template editor. The new backend routes `/email/templates/add` and `/email/templates/update` are used on the frontend. When a new templates is created, the return value from `/email/templates/add` is the automatically-generated ID the document was created with in Firestore. This is also the name of the HTML file to be uploaded to Storage. The IDs are generated so LSC does not have to worry about thinking of a unique ID for each email and we do not need to do checks to confirm that IDs are unique. Buttons disable when their respective requests are happening.

- [x] implemented add new template on frontend
- [x] implemented update template/save changes on frontend
- [x] new backend route `POST /email/templates/add`
- [x] new backend route `POST /email/templates/update`


POST `/email/templates/add` to create a new template, returning `"data": "K694tDCbkpkS2o6Eo9xe"` for template ID:
```json
{
  "name": "New template",
  "type": "group",
  "subject": "Study partners!"
}
```

POST `/email/templates/update` to update an existing template, returns 400 Bad Request if there is no existing template with that ID
```json
{
  "id": "K694tDCbkpkS2o6Eo9xe",
  "name": "Updated template",
  "type": "student",
  "subject": "Study partners!?"
}
```

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Visiting the template editor, the most recently edited template is shown, if there are none then it defaults to add template
![Screen Shot 2022-08-05 at 00 15 42](https://user-images.githubusercontent.com/22627336/183023469-28b0dd36-4f19-4d09-8184-d3087723ecff.png)

Adding a new template
![Screen Shot 2022-08-05 at 00 15 47](https://user-images.githubusercontent.com/22627336/183023474-8319134e-5efc-4b44-99c3-3dada2e5bba3.png)

Filling out the template fields
![Screen Shot 2022-08-05 at 00 17 07](https://user-images.githubusercontent.com/22627336/183023478-a015bdd6-6eb3-451d-b8ba-1ff9302fa980.png)

After creating the template, it is automatically selected on the left and the buttons change to cancel and save changes
![Screen Shot 2022-08-05 at 00 17 16](https://user-images.githubusercontent.com/22627336/183023486-ae86bfa2-cd09-4baf-a50b-f4082f745739.png)

The update/save changes button works pretty much how you would expect. There is no check "are there changes to save" since there is no diffing, it simply overrides the existing fields. The template also goes to the top on the left since it's now the most recently modified template.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
None

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
None
