### PR TITLE
Change roster to FA22

### DIFF
--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -61,7 +61,7 @@ export const addStudentSurveyResponse = async (
   year: string,
   courseCatalogNames: string[]
 ) => {
-  const roster = 'SU22' // Summer 2022 for LSC launch
+  const roster = 'FA22' // Fall 2022
 
   // 0. Check if email is valid cornell.edu email.
   const emailRegex = /^\w+@cornell.edu$/

--- a/frontend/src/modules/Survey/Components/StepBegin.tsx
+++ b/frontend/src/modules/Survey/Components/StepBegin.tsx
@@ -127,7 +127,7 @@ export const StepBegin = ({
           <TextField
             id="name"
             variant="standard"
-            placeholder="Student Name"
+            placeholder="Full Name"
             sx={textInputStyle}
             value={name}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Change the roster for classes that the survey uses to use Fall 2022 instead of Summer 2022. When students submit surveys now they will be added to the Fall 2022 iteration of the course.

- [x] change roster to FA22
- [x] minor survey wording change to use "Full Name"

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Student document, membership in two CS 1110
<img width="471" alt="Screen Shot 2022-08-06 at 23 52 39" src="https://user-images.githubusercontent.com/22627336/183279099-ddadb634-3db8-4119-903b-9ab4f91ea73e.png">

Courses collection, SU22-358526 and FA22-358526 are distinct and there are two classes on the dashboard
<img width="337" alt="Screen Shot 2022-08-06 at 23 52 19" src="https://user-images.githubusercontent.com/22627336/183279101-44a38dc6-b562-440b-871a-8d40a8529661.png">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

#66 made this so easy :)

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->

None