### PR TITLE
Email edit new templates

### DIFF
--- a/frontend/src/modules/Core/Components/RadioButtons.tsx
+++ b/frontend/src/modules/Core/Components/RadioButtons.tsx
@@ -6,6 +6,7 @@ import { RadioButtonsProps } from '@core/Types'
 import { StyledContainer } from '@core/Styles/RadioButtons.style'
 
 export const RadioButtons = ({
+  labels = [],
   values,
   onClick,
   currentAnswer,
@@ -17,7 +18,7 @@ export const RadioButtons = ({
           key={i}
           currentAnswer={currentAnswer}
           onClick={onClick}
-          value={value}
+          value={labels[i]}
           label={value}
           name="RadioButtons"
           checked={value === currentAnswer}

--- a/frontend/src/modules/Core/Components/RadioButtons.tsx
+++ b/frontend/src/modules/Core/Components/RadioButtons.tsx
@@ -7,7 +7,7 @@ import { StyledContainer } from '@core/Styles/RadioButtons.style'
 
 export const RadioButtons = ({
   labels = [],
-  values,
+  values = [],
   onClick,
   currentAnswer,
 }: RadioButtonsProps) => {
@@ -18,8 +18,8 @@ export const RadioButtons = ({
           key={i}
           currentAnswer={currentAnswer}
           onClick={onClick}
-          value={labels[i]}
-          label={value}
+          value={value}
+          label={labels[i]}
           name="RadioButtons"
           checked={value === currentAnswer}
         />

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -335,58 +335,55 @@ export const EmailModal = ({
   }
 
   return (
-    <>
-      <ZingModal
-        open={isEmailing}
-        onClose={() => setIsEmailing(!isEmailing)}
-        containerWidth={'800px'}
-        containerHeight={'630px'}
-      >
-        <ZingModal.Title onClose={() => setIsEmailing(!isEmailing)}>
-          <Box
-            display={'flex'}
-            justifyContent={'center'}
-            textAlign={'center'}
-            paddingTop="20px"
-          >
-            <Typography variant="h4" component="h4" fontWeight={'700'}>
-              {title}
-            </Typography>
+    <ZingModal
+      open={isEmailing}
+      onClose={() => setIsEmailing(!isEmailing)}
+      containerWidth={'800px'}
+      containerHeight={'630px'}
+    >
+      <ZingModal.Title onClose={() => setIsEmailing(!isEmailing)}>
+        <Box
+          display={'flex'}
+          justifyContent={'center'}
+          textAlign={'center'}
+          paddingTop="20px"
+        >
+          <Typography variant="h4" component="h4" fontWeight={'700'}>
+            {title}
+          </Typography>
+        </Box>
+      </ZingModal.Title>
+      <ZingModal.Body>
+        {selectedTemplate ? (
+          <Box sx={{ padding: '1rem 3.5rem 0 3.5rem' }}>
+            {step <= 1 && <SelectTemplates />}
+            {step === 2 && <StepFailure />}
+            {step === 3 && <StepFinalFailure />}
           </Box>
-        </ZingModal.Title>
-        <ZingModal.Body>
-          {selectedTemplate ? (
-            <Box sx={{ padding: '1rem 3.5rem 0 3.5rem' }}>
-              {step <= 1 && <SelectTemplates />}
-              {step === 2 && <StepFailure />}
-              {step === 3 && <StepFinalFailure />}
-            </Box>
-          ) : (
-            <Box
-              sx={{
-                padding: '1rem 3.5rem 0 3.5rem',
-                textAlign: 'center',
-                display: 'flex',
-                flexFlow: 'column nowrap',
-                gap: '10rem',
-                alignItems: 'center',
-              }}
-            >
-              <Typography variant="h5">
-                No Templates for the selected group.
-              </Typography>
-              <Button href="/templates" sx={{ width: '250px' }}>
-                Add Templates
-              </Button>
-            </Box>
-          )}
-        </ZingModal.Body>
-        <ZingModal.Controls>
-          <BackButton />
-          <ProceedButton />
-        </ZingModal.Controls>
-      </ZingModal>
-      )
-    </>
+        ) : (
+          <Box
+            sx={{
+              padding: '1rem 3.5rem 0 3.5rem',
+              textAlign: 'center',
+              display: 'flex',
+              flexFlow: 'column nowrap',
+              gap: '10rem',
+              alignItems: 'center',
+            }}
+          >
+            <Typography variant="h5">
+              No Templates for the selected group.
+            </Typography>
+            <Button href="/templates" sx={{ width: '250px' }}>
+              Add Templates
+            </Button>
+          </Box>
+        )}
+      </ZingModal.Body>
+      <ZingModal.Controls>
+        <BackButton />
+        <ProceedButton />
+      </ZingModal.Controls>
+    </ZingModal>
   )
 }

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -62,7 +62,6 @@ export const EmailModal = ({
         )
         setTemplates(filteredTemplates)
         setSelectedTemplate(filteredTemplates[0])
-        setTemplateName(selectedTemplate?.id || '')
       })
       .catch((error) => console.error(error))
   }, [recipientType])

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -108,8 +108,7 @@ export const EmailModal = ({
     await Promise.all(
       selectedStudents.map((student: string) => {
         const emailRcpts = [student, 'lscstudypartners@cornell.edu']
-        // const emailBody = getBody(selectedTemplate, courseNames.join(', '))
-        const emailSubject = 'Study Partners!'
+        const emailSubject = selectedTemplate.subject
         const emailItems = {
           emailSubject,
           emailRcpts,
@@ -132,8 +131,7 @@ export const EmailModal = ({
     await Promise.all(
       selectedGroups.map((group) => {
         const emailRcpts = groupEmails(group)
-        // const emailBody = getBody(selectedTemplate, courseNames.join(', '))
-        const emailSubject = 'Study Partners!'
+        const emailSubject = selectedTemplate.subject
         const groupNum = group.groupNumber.toString()
         const emailItems = {
           emailSubject,

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -38,10 +38,8 @@ export const EmailModal = ({
   // template editor logic
 
   const [templates, setTemplates] = useState<EmailTemplate[]>([])
-  const [templateName, setTemplateName] = useState('')
-  const [selectedTemplate, setSelectedTemplate] = useState<EmailTemplate>(
-    templates[0]
-  )
+  const [selectedTemplate, setSelectedTemplate] = useState<EmailTemplate>()
+  const [templateName, setTemplateName] = useState(selectedTemplate?.id || '')
 
   useEffect(() => {
     axios
@@ -64,6 +62,7 @@ export const EmailModal = ({
         )
         setTemplates(filteredTemplates)
         setSelectedTemplate(filteredTemplates[0])
+        setTemplateName(selectedTemplate?.id || '')
       })
       .catch((error) => console.error(error))
   }, [recipientType])
@@ -101,11 +100,11 @@ export const EmailModal = ({
     await Promise.all(
       selectedStudents.map((student: string) => {
         const emailRcpts = [student, 'lscstudypartners@cornell.edu']
-        const emailSubject = selectedTemplate.subject
+        const emailSubject = selectedTemplate?.subject
         const emailItems = {
           emailSubject,
           emailRcpts,
-          emailBody: selectedTemplate.html,
+          emailBody: selectedTemplate?.html,
           courseId,
           groupNum: -1,
           selectedTemplate,
@@ -124,12 +123,12 @@ export const EmailModal = ({
     await Promise.all(
       selectedGroups.map((group) => {
         const emailRcpts = groupEmails(group)
-        const emailSubject = selectedTemplate.subject
+        const emailSubject = selectedTemplate?.subject
         const groupNum = group.groupNumber.toString()
         const emailItems = {
           emailSubject,
           emailRcpts,
-          emailBody: selectedTemplate.html,
+          emailBody: selectedTemplate?.html,
           courseId,
           groupNum,
           selectedTemplate,
@@ -162,7 +161,7 @@ export const EmailModal = ({
         <Typography variant="h5" component="h5">
           Template:
           <Box component="span" sx={{ fontWeight: 800 }}>
-            {selectedTemplate.name}
+            {selectedTemplate?.name}
           </Box>
         </Typography>
       </Box>
@@ -187,7 +186,7 @@ export const EmailModal = ({
     return (
       <Box>
         <TemplateSelectedComponent />
-        <EmailPreview template={selectedTemplate} courseNames={courseNames} />
+        <EmailPreview template={selectedTemplate!} courseNames={courseNames} />
       </Box>
     )
   }
@@ -331,39 +330,51 @@ export const EmailModal = ({
   }
 
   return (
-    <ZingModal
-      open={isEmailing}
-      onClose={() => setIsEmailing(!isEmailing)}
-      containerWidth={'800px'}
-      containerHeight={'630px'}
-    >
-      <ZingModal.Title onClose={() => setIsEmailing(!isEmailing)}>
-        <Box
-          display={'flex'}
-          justifyContent={'center'}
-          textAlign={'center'}
-          paddingTop="20px"
-        >
-          <Typography variant="h4" component="h4" fontWeight={'700'}>
-            {title}
-          </Typography>
-        </Box>
-      </ZingModal.Title>
-      <ZingModal.Body>
-        <Box sx={{ padding: '1rem 3.5rem 0 3.5rem' }}>
-          {step === 2 ? (
-            <StepFailure />
-          ) : step === 3 ? (
-            <StepFinalFailure />
+    <>
+      <ZingModal
+        open={isEmailing}
+        onClose={() => setIsEmailing(!isEmailing)}
+        containerWidth={'800px'}
+        containerHeight={'630px'}
+      >
+        <ZingModal.Title onClose={() => setIsEmailing(!isEmailing)}>
+          <Box
+            display={'flex'}
+            justifyContent={'center'}
+            textAlign={'center'}
+            paddingTop="20px"
+          >
+            <Typography variant="h4" component="h4" fontWeight={'700'}>
+              {title}
+            </Typography>
+          </Box>
+        </ZingModal.Title>
+        <ZingModal.Body>
+          {selectedTemplate ? (
+            <Box sx={{ padding: '1rem 3.5rem 0 3.5rem' }}>
+              {step <= 1 && <SelectTemplates />}
+              {step === 2 && <StepFailure />}
+              {step === 3 && <StepFinalFailure />}
+            </Box>
           ) : (
-            <SelectTemplates />
+            <Box
+              sx={{
+                padding: '1rem 3.5rem 0 3.5rem',
+                textAlign: 'center',
+              }}
+            >
+              <Typography> Loading...</Typography>No Templates for the selected
+              group. Please goto
+              <a href="/templates"> Templates</a> to add some.
+            </Box>
           )}
-        </Box>
-      </ZingModal.Body>
-      <ZingModal.Controls>
-        <BackButton />
-        <ProceedButton />
-      </ZingModal.Controls>
-    </ZingModal>
+        </ZingModal.Body>
+        <ZingModal.Controls>
+          <BackButton />
+          <ProceedButton />
+        </ZingModal.Controls>
+      </ZingModal>
+      )
+    </>
   )
 }

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -36,10 +36,8 @@ export const EmailModal = ({
   const recipientType = selectedStudents.length > 0 ? 'student' : 'group'
 
   // template editor logic
-
   const [templates, setTemplates] = useState<EmailTemplate[]>([])
   const [selectedTemplate, setSelectedTemplate] = useState<EmailTemplate>()
-  const [templateName, setTemplateName] = useState(selectedTemplate?.id || '')
 
   useEffect(() => {
     axios
@@ -172,10 +170,8 @@ export const EmailModal = ({
       <Box>
         <EmailTemplateButtons
           templates={templates}
-          selectedTemplate={templates[0]}
+          selectedTemplate={selectedTemplate!}
           setSelectedTemplate={setSelectedTemplate}
-          templateName={templateName}
-          setTemplateName={setTemplateName}
         />
       </Box>
     )
@@ -201,15 +197,21 @@ export const EmailModal = ({
           justifyContent: 'center',
           alignItems: 'center',
           paddingTop: '8%',
+          flexFlow: 'column nowrap',
+          gap: '1rem',
         }}
       >
         <Typography variant="h5" component="h5" fontWeight={'400'}>
           Uh oh... Something went wrong when trying to send the email. Try again
-          to reauthenticate. <br></br>
-          <br></br>
-          <em>
-            *This will automatically attempt to send the email one more time.
-          </em>
+          to reauthenticate.
+        </Typography>
+        <Typography
+          variant="h5"
+          component="h5"
+          fontWeight={'400'}
+          sx={{ fontStyle: 'italic' }}
+        >
+          *This will automatically attempt to send the email one more time.
         </Typography>
         <Button
           onClick={() => {
@@ -234,18 +236,22 @@ export const EmailModal = ({
           justifyContent: 'center',
           alignItems: 'center',
           paddingTop: '8%',
+          flexFlow: 'column nowrap',
+          gap: '2rem',
         }}
       >
         <Typography variant="h5" component="h5" fontWeight={'400'}>
           Looks like something went wrong. Please contact DTI with the following
-          error reference for more information.
-          <br />
-          <br />
-          <Typography variant="h5" fontWeight="700">
-            Error reference:
-          </Typography>
-          Email final auth failure step.
+          error reference for more information. Try reloading, reloggin in, or
+          try again later.
         </Typography>
+        <Typography variant="h5" fontWeight="700">
+          Error reference:
+          <Typography variant="h5" component="h5" fontWeight={'400'}>
+            Email final auth failure step.
+          </Typography>
+        </Typography>
+
         <Button
           onClick={() => {
             setIsEmailing(false)
@@ -360,11 +366,18 @@ export const EmailModal = ({
               sx={{
                 padding: '1rem 3.5rem 0 3.5rem',
                 textAlign: 'center',
+                display: 'flex',
+                flexFlow: 'column nowrap',
+                gap: '10rem',
+                alignItems: 'center',
               }}
             >
-              <Typography> Loading...</Typography>No Templates for the selected
-              group. Please goto
-              <a href="/templates"> Templates</a> to add some.
+              <Typography variant="h5">
+                No Templates for the selected group.
+              </Typography>
+              <Button href="/templates" sx={{ width: '250px' }}>
+                Add Templates
+              </Button>
             </Box>
           )}
         </ZingModal.Body>

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -41,6 +41,7 @@ export const EmailModal = ({
 
   const [templates, setTemplates] = useState<EmailTemplate[]>([])
   const [selectedTemplateId, setSelectedTemplateId] = useState('')
+  const [templateName, setTemplateName] = useState('')
 
   useEffect(() => {
     axios
@@ -183,6 +184,8 @@ export const EmailModal = ({
           templates={templates}
           selectedTemplate={templates[0]}
           setSelectedTemplate={setSelectedTemplate}
+          templateName={templateName}
+          setTemplateName={setTemplateName}
         />
       </Box>
     )

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -34,6 +34,9 @@ export const EmailModal = ({
   setEmailSentError,
   handleEmailTimestamp,
 }: EmailModalProps) => {
+  // check if emailing students or groups
+  const recipientType = selectedStudents.length > 0 ? 'student' : 'group'
+
   // template editor logic
 
   const [templates, setTemplates] = useState<EmailTemplate[]>([])
@@ -56,7 +59,10 @@ export const EmailModal = ({
             })
         )
         console.log(templates)
-        setTemplates(templates)
+        const filteredTemplates = templates.filter(
+          (template) => template.type === recipientType
+        )
+        setTemplates(filteredTemplates)
         const mostRecentModifiedTemplate = templates.reduce((p, c) =>
           p.modifyTime.valueOf() > c.modifyTime.valueOf() ? p : c
         )

--- a/frontend/src/modules/EditZing/Components/EmailPreview.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailPreview.tsx
@@ -1,4 +1,3 @@
-import { getBody } from '../utils/emailTemplates'
 import { EmailPreviewProps } from 'EditZing/Types/ComponentProps'
 import { Box } from '@mui/material'
 import { Typography } from '@mui/material'

--- a/frontend/src/modules/EditZing/Components/EmailPreview.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailPreview.tsx
@@ -23,7 +23,6 @@ export const EmailPreview = ({ template, courseNames }: EmailPreviewProps) => {
     padding: '16px',
   }
 
-  // const body = getBody(templateName, courseNames.join(', '))
   const body = template.html
   return (
     <Box>

--- a/frontend/src/modules/EditZing/Components/EmailPreview.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailPreview.tsx
@@ -36,7 +36,7 @@ export const EmailPreview = ({ template, courseNames }: EmailPreviewProps) => {
       >
         <Box display={'flex'} flexDirection={'row'}>
           <Typography fontWeight={800}>Subject: </Typography>&nbsp;
-          <Typography>Study Partners!</Typography>
+          <Typography> {template.subject} </Typography>
         </Box>
       </Box>
       <Box

--- a/frontend/src/modules/EditZing/Components/EmailPreview.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailPreview.tsx
@@ -4,10 +4,7 @@ import { Box } from '@mui/material'
 import { Typography } from '@mui/material'
 import { SxProps } from '@mui/material'
 
-export const EmailPreview = ({
-  templateName,
-  courseNames,
-}: EmailPreviewProps) => {
+export const EmailPreview = ({ template, courseNames }: EmailPreviewProps) => {
   const TitleSx: SxProps = {
     color: 'essentials.6',
     backgroundColor: 'essentials.75',
@@ -27,7 +24,8 @@ export const EmailPreview = ({
     padding: '16px',
   }
 
-  const body = getBody(templateName, courseNames.join(', '))
+  // const body = getBody(templateName, courseNames.join(', '))
+  const body = template.html
   return (
     <Box>
       <Box sx={TitleSx}>Email Preview</Box>

--- a/frontend/src/modules/EditZing/Components/EmailPreview.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailPreview.tsx
@@ -35,7 +35,7 @@ export const EmailPreview = ({ template, courseNames }: EmailPreviewProps) => {
       >
         <Box display={'flex'} flexDirection={'row'}>
           <Typography fontWeight={800}>Subject: </Typography>&nbsp;
-          <Typography> {template.subject} </Typography>
+          <Typography>{template.subject}</Typography>
         </Box>
       </Box>
       <Box

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -2,20 +2,31 @@ import { Box, Typography } from '@mui/material'
 import { RadioButtons } from '@core/Components'
 import { TemplateName } from 'EditZing/utils/emailTemplates'
 import { TemplateRadioButtonsProps } from 'EditZing/Types/ComponentProps'
+import { useState } from 'react'
 
 export const EmailTemplateButtons = ({
+  templates,
   selectedTemplate,
   setSelectedTemplate,
 }: TemplateRadioButtonsProps) => {
   // we could include all, but designers advise to limit it to just these few for now
-  const activeTemplates = [
-    TemplateName.MATCHED,
-    TemplateName.CHECK_IN,
-    TemplateName.ADD_STUDENT,
-  ]
+  // const activeTemplates = [
+  //   TemplateName.MATCHED,
+  //   TemplateName.CHECK_IN,
+  //   TemplateName.ADD_STUDENT,
+  // ]
+
+  const [templateName, setTemplateName] = useState('')
+  const templateNames = templates.map((template) => template.name)
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedTemplate(event.target.value as TemplateName)
+    const choice = event.target.value
+    setTemplateName(choice)
+    templates.forEach((template) => {
+      if (template.name === choice) {
+        setSelectedTemplate(template)
+      }
+    })
   }
 
   return (
@@ -30,9 +41,9 @@ export const EmailTemplateButtons = ({
         Use an existing template:
       </Typography>
       <RadioButtons
-        values={activeTemplates}
+        values={templateNames}
         onClick={handleChange}
-        currentAnswer={selectedTemplate}
+        currentAnswer={templateName}
       />
     </Box>
   )

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -1,8 +1,6 @@
 import { Box, Typography } from '@mui/material'
 import { RadioButtons } from '@core/Components'
-import { TemplateName } from 'EditZing/utils/emailTemplates'
 import { TemplateRadioButtonsProps } from 'EditZing/Types/ComponentProps'
-import { useState } from 'react'
 
 export const EmailTemplateButtons = ({
   templates,

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -42,8 +42,8 @@ export const EmailTemplateButtons = ({
         Use an existing template:
       </Typography>
       <RadioButtons
-        labels={templateIds}
-        values={templateNames}
+        labels={templateNames}
+        values={templateIds}
         onClick={handleChange}
         currentAnswer={templateName}
       />

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -14,11 +14,9 @@ export const EmailTemplateButtons = ({
   // changing the selected email template
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newSelection = event.target.value
-    templates.forEach((template) => {
-      if (template.id === newSelection) {
-        setSelectedTemplate(template)
-      }
-    })
+    setSelectedTemplate(
+      templates.find((template) => template.id === newSelection)!
+    )
   }
 
   return (

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -8,6 +8,8 @@ export const EmailTemplateButtons = ({
   templates,
   selectedTemplate,
   setSelectedTemplate,
+  templateName,
+  setTemplateName,
 }: TemplateRadioButtonsProps) => {
   // we could include all, but designers advise to limit it to just these few for now
   // const activeTemplates = [
@@ -16,17 +18,16 @@ export const EmailTemplateButtons = ({
   //   TemplateName.ADD_STUDENT,
   // ]
 
-  const [templateName, setTemplateName] = useState('')
   const templateNames = templates.map((template) => template.name)
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const choice = event.target.value
-    setTemplateName(choice)
     templates.forEach((template) => {
       if (template.name === choice) {
         setSelectedTemplate(template)
       }
     })
+    setTemplateName(selectedTemplate.name)
   }
 
   return (

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -25,7 +25,7 @@ export const EmailTemplateButtons = ({
         setSelectedTemplate(template)
       }
     })
-    setTemplateName(selectedTemplate.name)
+    setTemplateName(event.target.value)
   }
 
   return (

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -6,30 +6,21 @@ export const EmailTemplateButtons = ({
   templates,
   selectedTemplate,
   setSelectedTemplate,
-  templateName,
-  setTemplateName,
 }: TemplateRadioButtonsProps) => {
-  // we could include all, but designers advise to limit it to just these few for now
-  // const activeTemplates = [
-  //   TemplateName.MATCHED,
-  //   TemplateName.CHECK_IN,
-  //   TemplateName.ADD_STUDENT,
-  // ]
-
+  // labels and values fot the radio button
   const templateNames = templates.map((template) => template.name)
   const templateIds = templates.map((template) => template.id)
 
+  // changing the selected email template
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const choice = event.target.value
+    const newSelection = event.target.value
     templates.forEach((template) => {
-      if (template.id === choice) {
+      if (template.id === newSelection) {
         setSelectedTemplate(template)
       }
     })
-    setTemplateName(event.target.value)
   }
 
-  console.log('Selected template: ', templateName)
   return (
     <Box
       sx={{
@@ -45,7 +36,7 @@ export const EmailTemplateButtons = ({
         labels={templateNames}
         values={templateIds}
         onClick={handleChange}
-        currentAnswer={templateName}
+        currentAnswer={selectedTemplate.id}
       />
     </Box>
   )

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -17,17 +17,19 @@ export const EmailTemplateButtons = ({
   // ]
 
   const templateNames = templates.map((template) => template.name)
+  const templateIds = templates.map((template) => template.id)
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const choice = event.target.value
     templates.forEach((template) => {
-      if (template.name === choice) {
+      if (template.id === choice) {
         setSelectedTemplate(template)
       }
     })
     setTemplateName(event.target.value)
   }
 
+  console.log('Selected template: ', templateName)
   return (
     <Box
       sx={{
@@ -40,6 +42,7 @@ export const EmailTemplateButtons = ({
         Use an existing template:
       </Typography>
       <RadioButtons
+        labels={templateIds}
         values={templateNames}
         onClick={handleChange}
         currentAnswer={templateName}

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -132,7 +132,6 @@ const GroupCard = ({
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fit, minmax(112px, max-content))',
             gap: '16px',
-            justifyContent: 'center',
           }}
         >
           {studentList.map((student, index) => (

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -2,6 +2,7 @@ import { GridSize } from '@mui/material'
 import { Student } from './Student'
 import { Group } from './CourseInfo'
 import { TemplateName } from 'EditZing/utils/emailTemplates'
+import { EmailTemplate } from '@core/Types'
 
 export interface UnmatchedGridProps {
   courseId: string
@@ -75,8 +76,9 @@ export interface NotesModalProps {
 }
 
 export interface TemplateRadioButtonsProps {
-  selectedTemplate: string
-  setSelectedTemplate: (value: TemplateName) => void
+  selectedTemplate: EmailTemplate
+  setSelectedTemplate: (value: EmailTemplate) => void
+  templates: EmailTemplate[]
 }
 
 export interface EmailModalContentProps {
@@ -87,6 +89,6 @@ export interface EmailModalContentProps {
 }
 
 export interface EmailPreviewProps {
-  templateName: TemplateName
+  template: EmailTemplate
   courseNames: string[]
 }

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -79,8 +79,6 @@ export interface TemplateRadioButtonsProps {
   selectedTemplate: EmailTemplate
   setSelectedTemplate: (value: EmailTemplate) => void
   templates: EmailTemplate[]
-  templateName: string
-  setTemplateName: (value: string) => void
 }
 
 export interface EmailModalContentProps {

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -79,6 +79,8 @@ export interface TemplateRadioButtonsProps {
   selectedTemplate: EmailTemplate
   setSelectedTemplate: (value: EmailTemplate) => void
   templates: EmailTemplate[]
+  templateName: string
+  setTemplateName: (value: string) => void
 }
 
 export interface EmailModalContentProps {

--- a/frontend/src/modules/Emailing/Components/Emailing.tsx
+++ b/frontend/src/modules/Emailing/Components/Emailing.tsx
@@ -167,27 +167,20 @@ export const sendEmail = async (emailItems: any) => {
       template: selectedTemplate,
       authToken: msAuthToken,
     },
-  }).then(async (res) => {
+  }).then((res) => {
     // 4. reading response for success or failure
     console.log(res)
-    if (res.data === 'Email send success.') {
+    if (res.data.success === true) {
       emailSent = true
     } else {
       // handle error
       emailSent = false
       console.log('Email send error. Please try again.')
-      console.log(res)
+      console.log(res.data)
       throw new Error(`API call to send email failed.`)
-
-      /* firebase login requires user action (ie. press button) will throw error 
-          if we try to call it straight up. 
-          
-          option1: 
-          set email send error to true 
-          frontend: if (err) { render try again button onClick => { adminLogin().then(sendEmail())} } */
     }
   })
 
-  // bool true if succ false if fail
+  // bool true if succ false if fail (just a current safeguard return for now, should be handled by a try catch)
   return emailSent
 }


### PR DESCRIPTION
# Summary 

This PR replaces the current hardcoded emailing templates that are selectable from the frontend email modal. 

- [x] Displays the email templates found in the `email_templates` collection. (run scripts in #86) 
- [x] Currently works and sends the 2 example templates HTML body. 
- [x] Also small style tweak of the group card when displaying a singular student card, displays it as grid-like. 

This PR is part of the frontend portion that continues off of #86 for custom email templates. 


# Test Plan 

1. Be sure to run the scripts in #86 to get the example templates 
2. Match students to groups 
3. Try emailing students and groups separately -> Should see a different list (1 item) based on if you selected to email students or groups. 

### With a group selected: 
<img width="1592" alt="image" src="https://user-images.githubusercontent.com/46132945/183339992-cb91be7e-0e9f-46ee-aef6-a8310d0ae81c.png">
<img width="919" alt="image" src="https://user-images.githubusercontent.com/46132945/183340022-4639a45b-6a44-4229-9b5e-4b14e947461a.png">

### With a student selected: 
<img width="1463" alt="image" src="https://user-images.githubusercontent.com/46132945/183340054-316d1645-5c69-4690-a4cf-cab84a3a7866.png">
<img width="900" alt="image" src="https://user-images.githubusercontent.com/46132945/183340076-7109c6ba-7c1b-4c5b-8a88-3be27badb42f.png">

### Notes 

- Also changes the logic to check if the email was sent successfully. (Not sure how it managed to work before)
- No longer uses the old templates. Is possible to delete/remove the hard-coded templates and logic code in the future or reuse it somehow. 
