### PR TITLE
Menu Box Shadows Fixed

### DIFF
--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -278,10 +278,11 @@ theme = createTheme(theme, {
       },
       styleOverrides: {
         root: {
-          boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.15)',
+          '& .MuiPaper-root': {
+            boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.15)',
+          },
         },
         list: {
-          boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.15)',
           '& .MuiMenuItem-root': {
             '&:hover': {
               backgroundColor: theme.palette.purple[16],
@@ -289,7 +290,6 @@ theme = createTheme(theme, {
           },
         },
         paper: {
-          boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.15)',
           marginTop: '4px',
         },
       },


### PR DESCRIPTION
# Summary 

Figured out how to fix the box shadows. Was the MuiPaper-root property. 

Didn't think I would be able to fix it so I already merged old PR woops.

# Test Plan 
<img width="384" alt="image" src="https://user-images.githubusercontent.com/46132945/184383735-7304dc5e-2526-4f2b-b659-c3f4873e1442.png">

