### PR TITLE
Implement Filtering by Unsent Check-In Email

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -27,6 +27,7 @@ type SortOrder =
   | 'matchable-first'
   | 'classes-a-z'
   | 'classes-z-a'
+  | 'no-check-in-email'
 
 export const Dashboard = () => {
   const { user } = useAuthValue()
@@ -100,6 +101,14 @@ export const Dashboard = () => {
     setRosterAnchorEl(null)
   }
 
+  //Helper function to check if a given course has any groups without check-in emails
+  function hasUnsentCheckIns(c: Course) {
+    return c.groups.some(
+      //checks whether a group has a check-in timestamp
+      (group) => !group.templateTimestamps['check-in']
+    )
+  }
+
   // (a,b) = -1 if a before b, 1 if a after b, 0 if equal
   function sorted(courseInfo: Course[], menuValue: SortOrder) {
     switch (menuValue) {
@@ -133,7 +142,7 @@ export const Dashboard = () => {
           } else return 1
         })
       case 'classes-a-z':
-        return [...courseInfo].sort((a, b) => {
+        return courseInfo.sort((a, b) => {
           return a.names[0].localeCompare(b.names[0], undefined, {
             numeric: true,
           })
@@ -144,6 +153,8 @@ export const Dashboard = () => {
             numeric: true,
           })
         })
+      case 'no-check-in-email':
+        return courseInfo.filter(hasUnsentCheckIns)
       default:
         return courseInfo
     }
@@ -195,6 +206,9 @@ export const Dashboard = () => {
             <MenuItem value="matchable-first">Matchable first</MenuItem>
             <MenuItem value="classes-a-z">Classes A-Z</MenuItem>
             <MenuItem value="classes-z-a">Classes Z-A</MenuItem>
+            <MenuItem value="no-check-in-email">
+              Unsent Check-in Emails{' '}
+            </MenuItem>
           </DropdownSelect>
         </Box>
         <Button

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -103,10 +103,7 @@ export const Dashboard = () => {
 
   //Helper function to check if a given course has any groups without check-in emails
   function hasUnsentCheckIns(c: Course) {
-    return c.groups.some(
-      //checks whether a group has a check-in timestamp
-      (group) => !group.templateTimestamps['check-in']
-    )
+    return c.groups.some((group) => !group.templateTimestamps['check-in'])
   }
 
   // (a,b) = -1 if a before b, 1 if a after b, 0 if equal
@@ -207,7 +204,7 @@ export const Dashboard = () => {
             <MenuItem value="classes-a-z">Classes A-Z</MenuItem>
             <MenuItem value="classes-z-a">Classes Z-A</MenuItem>
             <MenuItem value="no-check-in-email">
-              Unsent Check-in Emails{' '}
+              Unsent Check-in Emails
             </MenuItem>
           </DropdownSelect>
         </Box>

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -139,7 +139,7 @@ export const Dashboard = () => {
           } else return 1
         })
       case 'classes-a-z':
-        return courseInfo.sort((a, b) => {
+        return [...courseInfo].sort((a, b) => {
           return a.names[0].localeCompare(b.names[0], undefined, {
             numeric: true,
           })


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements a filtering option that only displays courses where not all groups have recieved check-in emails yet.

- [x] implemented filtering by unreceived check-in email
- [x] added new filtering option to "sort by" dropdown 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Testing was done by populating the firestore database using `npm run populate,` making matches, and sending check-in emails to some groups in certain courses but not others, and then verifying that the correct courses show up when filtering.

<img width="957" alt="Screen Shot 2022-08-23 at 4 30 11 PM" src="https://user-images.githubusercontent.com/45516888/186259822-6934284a-2c4f-431a-973f-2f6384708659.png">