### PR TITLE
implement filter for courses with unsent no match emails

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -28,6 +28,7 @@ type SortOrder =
   | 'classes-a-z'
   | 'classes-z-a'
   | 'no-check-in-email'
+  | 'no-match-email'
 
 export const Dashboard = () => {
   const { user } = useAuthValue()
@@ -106,6 +107,26 @@ export const Dashboard = () => {
     return c.groups.some((group) => !group.templateTimestamps['check-in'])
   }
 
+  //Helper function that returns true if the student doesn't have a no match email
+  function studentHasUnsentNoMatch(smail: string, courseId: string) {
+    const student = students.find((s) => s.email === smail)
+    if (!student) {
+      throw Error(`Student with email ${smail} not found`)
+    }
+    const group = student.groups.find((g) => g.courseId === courseId)
+    if (!group) {
+      throw Error(`Student with email ${smail} not found in course ${courseId}`)
+    }
+    return !group.templateTimestamps['no-match-yet']
+  }
+
+  //Helper function that returns true if an unmatched student in a course doesn't have a no match email
+  function hasUnsentNoMatch(c: Course) {
+    return c.unmatched.some((email) =>
+      studentHasUnsentNoMatch(email, c.courseId)
+    )
+  }
+
   // (a,b) = -1 if a before b, 1 if a after b, 0 if equal
   function sorted(courseInfo: Course[], menuValue: SortOrder) {
     switch (menuValue) {
@@ -152,6 +173,8 @@ export const Dashboard = () => {
         })
       case 'no-check-in-email':
         return courseInfo.filter(hasUnsentCheckIns)
+      case 'no-match-email':
+        return courseInfo.filter(hasUnsentNoMatch)
       default:
         return courseInfo
     }
@@ -206,6 +229,7 @@ export const Dashboard = () => {
             <MenuItem value="no-check-in-email">
               Unsent Check-in Emails
             </MenuItem>
+            <MenuItem value="no-match-email">Unsent No Match Emails</MenuItem>
           </DropdownSelect>
         </Box>
         <Button

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -28,7 +28,7 @@ type SortOrder =
   | 'classes-a-z'
   | 'classes-z-a'
   | 'no-check-in-email'
-  | 'no-match-email'
+  | 'no-no-match-email'
 
 export const Dashboard = () => {
   const { user } = useAuthValue()
@@ -173,7 +173,7 @@ export const Dashboard = () => {
         })
       case 'no-check-in-email':
         return courseInfo.filter(hasUnsentCheckIns)
-      case 'no-match-email':
+      case 'no-no-match-email':
         return courseInfo.filter(hasUnsentNoMatch)
       default:
         return courseInfo


### PR DESCRIPTION
### Summary
This pull request implements a filtering option that only displays courses where not all unmatched students have recieved a no match email yet.

 - [x] implemented filtering by unreceived no-match email
 - [x] added new filtering option to "sort by" dropdown

### Test Plan
Testing was done by populating the firestore database using npm run populate, making matches, and sending no-match emails to some unmatched students in certain courses but not others, and then verifying that the correct courses show up when filtering.

<img width="913" alt="Screen Shot 2022-08-25 at 12 05 12 AM" src="https://user-images.githubusercontent.com/45516888/186572311-37e36f9e-8f38-4c91-9176-16cd80e2a8ba.png">