### PR TITLE
Add individual email timestamps to student csv export

### DIFF
--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -1,4 +1,4 @@
-//import axios from 'axios'
+import axios from 'axios'
 
 // firebase imports
 import admin from 'firebase-admin'
@@ -70,7 +70,7 @@ export const updateIndivTimestamp = async (
 }
 
 /* ==== Emailing Helper Functions ==== */
-//const GRAPH_ENDPOINT = 'https://graph.microsoft.com'
+const GRAPH_ENDPOINT = 'https://graph.microsoft.com'
 
 /**
  * Returns the list of recipients of an email based on group/individual membership
@@ -210,7 +210,7 @@ const sendMails = async (
     throw new Error('Both group and individual email are specified')
   }
 
-  /* const response = await axios({
+  const response = await axios({
     url: `${GRAPH_ENDPOINT}/v1.0/users/${from}/sendMail`,
     // url: 'https://graph.microsoft.com/v1.0/users/wz282@cornell.edu/sendMail',
     method: 'POST',
@@ -219,9 +219,7 @@ const sendMails = async (
       'Content-Type': 'application/json',
     },
     data: JSON.stringify(message),
-  }) */
-
-  const response = { status: 202 }
+  })
 
   if (response.status === 202) {
     if (group && parseInt(group) > 0) {

--- a/backend/functions/src/emailing/functions.ts
+++ b/backend/functions/src/emailing/functions.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+//import axios from 'axios'
 
 // firebase imports
 import admin from 'firebase-admin'
@@ -70,7 +70,7 @@ export const updateIndivTimestamp = async (
 }
 
 /* ==== Emailing Helper Functions ==== */
-const GRAPH_ENDPOINT = 'https://graph.microsoft.com'
+//const GRAPH_ENDPOINT = 'https://graph.microsoft.com'
 
 /**
  * Returns the list of recipients of an email based on group/individual membership
@@ -210,7 +210,7 @@ const sendMails = async (
     throw new Error('Both group and individual email are specified')
   }
 
-  const response = await axios({
+  /* const response = await axios({
     url: `${GRAPH_ENDPOINT}/v1.0/users/${from}/sendMail`,
     // url: 'https://graph.microsoft.com/v1.0/users/wz282@cornell.edu/sendMail',
     method: 'POST',
@@ -219,7 +219,9 @@ const sendMails = async (
       'Content-Type': 'application/json',
     },
     data: JSON.stringify(message),
-  })
+  }) */
+
+  const response = { status: 202 }
 
   if (response.status === 202) {
     if (group && parseInt(group) > 0) {

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -87,6 +87,7 @@ export const Dashboard = () => {
                   ? `${course.names.join('/')}_${membership.groupNumber}`
                   : undefined,
               ...localeMap(group?.templateTimestamps),
+              ...localeMap(membership.templateTimestamps),
               notes: membership.notes,
             }
           })


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds template timestamps associated with emailing individuals into the exported student csv.

- [x] implemented showing individual email timestamps in the student csv

### Test Plan <!-- Required -->

Testing was conducted by sending nomatch emails to example students and checking if the exported student csv file is updated with the correct email timestamps:

<img width="995" alt="Screen Shot 2022-09-22 at 6 15 24 PM" src="https://user-images.githubusercontent.com/45516888/191861815-21587005-83d7-487d-ab7c-c3af0009fcd8.png">
