### PR TITLE
Add Firebase logging for API requests

### DIFF
--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -44,7 +44,7 @@ app.use('/email', [checkAuth, checkIsAuthorized], emailRouter)
 app.get('/getauth', checkAuth, (req, res) => {
   if (req.headers?.authorization?.startsWith('Bearer ')) {
     const idToken = req.headers.authorization.split('Bearer ')[1]
-    checkIsAuthorizedFromToken(idToken).then((isAuthed) => {
+    checkIsAuthorizedFromToken(req, idToken).then((isAuthed) => {
       res.status(200).send({
         success: true,
         data: { isAuthed: isAuthed },

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -6,6 +6,7 @@ import {
   checkAuth,
   checkIsAuthorized,
   checkIsAuthorizedFromToken,
+  logReqBody,
 } from './middleware/auth-middleware'
 import { unless } from './middleware/unless'
 
@@ -28,6 +29,7 @@ const app = express()
 
 app.use(express.json())
 app.use(cors())
+app.use(logReqBody)
 
 // auth middleware before router
 app.use(

--- a/backend/functions/src/middleware/auth-middleware.ts
+++ b/backend/functions/src/middleware/auth-middleware.ts
@@ -46,27 +46,38 @@ export function checkAuth(req: Request, res: Response, next: NextFunction) {
 
 export function logReqBody(req: Request, res: Response, next: NextFunction) {
   // TODO (richardgu): find a way to also log which endpoint is being hit
-  let output = `Request Endpoint: ${req.originalUrl}\n
-  Request Params: ${JSON.stringify(req.params)}\nRequest Body: ${JSON.stringify(
-    req.body
-  )}\n`
+  let output = `Request Endpoint: ${req.originalUrl}  `
   if (Object.keys(req.params).length > 0) {
-    output += 'REQUEST PARAMS...\n'
+    output += 'REQUEST PARAMS: {'
+    let ind = 0
     for (const key in req.params) {
       const val = req.params[key]
-      output += `${JSON.stringify(key)}: ${JSON.stringify(val)}\n`
+      output += `${JSON.stringify(key).substring(
+        1,
+        JSON.stringify(key).length - 1
+      )}: ${JSON.stringify(val).substring(1, JSON.stringify(val).length - 1)}`
+      if (ind < Object.keys(req.params).length - 1) output += ', '
+      ind++
     }
+    output += '}'
   } else {
-    output += 'Request params is empty\n'
+    output += 'Request params is empty.  '
   }
   if (Object.keys(req.body).length > 0) {
-    output += 'REQUEST BODY...\n'
+    output += 'REQUEST BODY: {'
+    let ind = 0
     for (const key in req.body) {
       const val = req.body[key]
-      output += `${JSON.stringify(key)}: ${JSON.stringify(val)}\n`
+      output += `${JSON.stringify(key).substring(
+        1,
+        JSON.stringify(key).length - 1
+      )}: ${JSON.stringify(val).substring(1, JSON.stringify(val).length - 1)}`
+      if (ind < Object.keys(req.body).length - 1) output += ', '
+      ind++
     }
+    output += '}'
   } else {
-    output += 'Request body is empty'
+    output += 'Request body is empty.  '
   }
   logger.info(output)
   next()

--- a/backend/functions/src/middleware/auth-middleware.ts
+++ b/backend/functions/src/middleware/auth-middleware.ts
@@ -46,12 +46,29 @@ export function checkAuth(req: Request, res: Response, next: NextFunction) {
 
 export function logReqBody(req: Request, res: Response, next: NextFunction) {
   // TODO (richardgu): find a way to also log which endpoint is being hit
-  logger.info(`Request params: `)
-  for (const key in req.params) {
-    const value = req.params[key]
-    logger.info(`Param ${key} = ${value}`)
+  let output = `Request Endpoint: ${req.originalUrl}\n
+  Request Params: ${JSON.stringify(req.params)}\nRequest Body: ${JSON.stringify(
+    req.body
+  )}\n`
+  if (Object.keys(req.params).length > 0) {
+    output += 'REQUEST PARAMS...\n'
+    for (const key in req.params) {
+      const val = req.params[key]
+      output += `${JSON.stringify(key)}: ${JSON.stringify(val)}\n`
+    }
+  } else {
+    output += 'Request params is empty\n'
   }
-  logger.info(`Request body: ${req.body}`)
+  if (Object.keys(req.body).length > 0) {
+    output += 'REQUEST BODY...\n'
+    for (const key in req.body) {
+      const val = req.body[key]
+      output += `${JSON.stringify(key)}: ${JSON.stringify(val)}\n`
+    }
+  } else {
+    output += 'Request body is empty'
+  }
+  logger.info(output)
   next()
 }
 

--- a/backend/functions/src/middleware/auth-middleware.ts
+++ b/backend/functions/src/middleware/auth-middleware.ts
@@ -48,7 +48,7 @@ export function logReqBody(req: Request, res: Response, next: NextFunction) {
   logger.info({
     request_type: req.method,
     endpoint: req.originalUrl,
-    params: JSON.stringify(req.params),
+    params: req.params,
     body: req.body,
   })
   next()

--- a/backend/functions/src/middleware/auth-middleware.ts
+++ b/backend/functions/src/middleware/auth-middleware.ts
@@ -1,6 +1,7 @@
 const { db } = require('../config')
 import * as admin from 'firebase-admin'
 import { Request, Response, NextFunction } from 'express'
+import { logger } from 'firebase-functions'
 import { firestore } from 'firebase-admin'
 import QuerySnapshot = firestore.QuerySnapshot
 
@@ -43,10 +44,22 @@ export function checkAuth(req: Request, res: Response, next: NextFunction) {
   }
 }
 
+export function logReqBody(req: Request, res: Response, next: NextFunction) {
+  // TODO (richardgu): find a way to also log which endpoint is being hit
+  logger.info(`Request params: `)
+  for (const key in req.params) {
+    const value = req.params[key]
+    logger.info(`Param ${key} = ${value}`)
+  }
+  logger.info(`Request body: ${req.body}`)
+  next()
+}
+
 export async function checkIsAuthorizedFromToken(idToken: string) {
   const decodedToken = await admin.auth().verifyIdToken(idToken)
   const uid = decodedToken.uid
   const user = await admin.auth().getUser(uid)
+  logger.info(`Called by user ${user.displayName} with uid ${user.uid}`)
   return !!(user.email && allowedUsers.includes(user.email))
 }
 


### PR DESCRIPTION
### Summary of Changes <!-- Required -->

Added basic logging for all API requests 

- for requests that require authorization, we log user uid and display name in Firebase 
- for all requests, added a new middleware function that logs request params and request body
<img width="1405" alt="Screen Shot 2022-10-20 at 7 46 29 PM" src="https://user-images.githubusercontent.com/100158738/197080473-aed9ade6-a794-4682-974c-3931723c8044.png">

<img width="537" alt="Screen Shot 2022-10-20 at 7 36 02 PM" src="https://user-images.githubusercontent.com/100158738/197080481-301698dd-6eb3-40ad-9c92-3becf1675593.png">


10/20 Changes 

- simplified everything by outputting stuff using JSON 
- logged request type as well


10/13 Changes 

- added request endpoint, params, and body to a single log output
- trying to format it nicely but \n for newline doesn't work for some reason
### Testing 
Caller info shows up in the log when we first log into Zing LSC:
<img width="1405" alt="Screen Shot 2022-10-13 at 3 35 38 PM" src="https://user-images.githubusercontent.com/100158738/195693501-488b2021-c450-44b9-a248-b4712f3c43ce.png">

Logging still works when we submit a form and match students for a course:
<img width="1406" alt="Screen Shot 2022-10-13 at 3 36 53 PM" src="https://user-images.githubusercontent.com/100158738/195693529-48d0a52c-d793-43b3-9645-21ca25816b4b.png">

Mostly outputs everything as expected but new lines aren't working:
<img width="1346" alt="Screen Shot 2022-10-13 at 8 23 21 PM" src="https://user-images.githubusercontent.com/100158738/195735154-cc114ddd-1cfe-4b7f-baa0-6de9685c9db8.png">


### Todo <!-- Optional -->
Request params are currently showing up as empty 
Find a way to also log which endpoint(s) are being hit 

