### PR TITLE
fixed ordering of groups to numerical order

### DIFF
--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import axios, { AxiosResponse } from 'axios'
 import GroupCard from 'EditZing/Components/GroupCard'
 import { UnmatchedGrid } from './UnmatchedGrid'
-import { EmailTemplatesResponse } from '@core/Types'
+import { EmailTemplatesResponse, Group } from '@core/Types'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { API_ROOT, EMAIL_PATH } from '@core/Constants'
@@ -45,6 +45,8 @@ export const EditZing = () => {
 
   const unmatchedStudents = getStudentsFromEmails(course?.unmatched ?? [])
   const studentGroups = course?.groups ?? []
+  const copyStudentGroups: Group[] = [...studentGroups]
+  copyStudentGroups.sort((a, b) => a.groupNumber - b.groupNumber)
 
   const [isEmailing, setIsEmailing] = useState<boolean>(false)
 
@@ -276,7 +278,7 @@ export const EditZing = () => {
                 updateNotes={updateNotes}
               />
             </Box>
-            {studentGroups.map((studentGroup) => (
+            {copyStudentGroups.map((studentGroup) => (
               <GroupCard
                 key={studentGroup.groupNumber}
                 courseId={courseId}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

These changes fixes the ordering of groups from alphabetical ordering to numerical ordering. The main issue previously was that when the groups were first formed, groups were formed in numerical order, however in Firebase it was stored in alphabetical order.  When it is called upon loading the page, it is called in the order that exists in Firebase, which is alphabetical rather than in numerical order. 

### Test Plan <!-- Required -->

![image](https://user-images.githubusercontent.com/64031655/195726505-06439637-cf09-4bde-b902-00be989ac95a.png)
Groups now go from [1 -> 2 -> ... -> 9 -> 10 -> 11] instead of [1 -> 10 -> 11 -> ... -> 2]

![image](https://user-images.githubusercontent.com/64031655/195726626-1128c8ce-738f-4ea2-bcae-ec1a98fc7589.png)
The students in each group was also made sure to be the same 

![image](https://user-images.githubusercontent.com/64031655/195727539-31fcf5f3-c086-4693-aba7-0a75dea6e0a9.png)
Unmatching and reassigning students still keeps wanted order upon reload
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

A copy of studentGroups, [copyStudentGroups] was created and sorted, and that is what's being mapped in the frontend. This hopefully shouldn't cause any issues since studentGroups still exists


<!--- List any important or subtle points, future considerations, or other items of note. -->

