### PR TITLE
line breaks show on same line when opening csv file

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -90,7 +90,7 @@ export const Dashboard = () => {
                   : undefined,
               ...localeMap(group?.templateTimestamps),
               ...localeMap(membership.templateTimestamps),
-              notes: membership.notes.replace(/(\n)/gm, '\\n').trim(),
+              notes: membership.notes.replace(/(\n)/gm, '  ').trim(),
             }
           })
         )

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -90,7 +90,7 @@ export const Dashboard = () => {
                   : undefined,
               ...localeMap(group?.templateTimestamps),
               ...localeMap(membership.templateTimestamps),
-              notes: membership.notes,
+              notes: membership.notes.replace(/(\n)/gm, '\\n').trim(),
             }
           })
         )


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the bug where there are actual line breaks when viewing the file rather than `\n`. 

### Test Plan <!-- Required -->
Previously, when there were multiple line breaks, it would take up multiple lines in the csv file
![Untitled](https://user-images.githubusercontent.com/64031655/197079433-c1089f51-83e2-4bfd-bbaa-a21180b3acf5.png)


Now, they are separated by `\n`
![Untitled](https://user-images.githubusercontent.com/64031655/197062127-26790f8f-a292-4b46-b962-6b8adb3b7ccf.png)


### Notes <!-- Optional -->
Only thing that might be of concern is if you were viewing the graphical version of the csv, you would see `\n` rather than the line breaks
![image](https://user-images.githubusercontent.com/64031655/197062282-51fb574f-5fd8-4447-beb6-f250babf9979.png)

As of right now, I don't think there's anyway to show the global modifier on the csv file but not in excel since that would depend on your OS
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

