### PR TITLE
Fix export noncurrent semesters

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -293,7 +293,10 @@ export const Dashboard = () => {
             horizontal: 'right',
           }}
         >
-          <CSVLink data={csvCourses} filename={`export-courses-${Date.now()}`}>
+          <CSVLink
+            data={csvCourses.filter((e) => e.semester === 'FA22')}
+            filename={`export-courses-${Date.now()}`}
+          >
             <MenuItem>Export CSV (Courses)</MenuItem>
           </CSVLink>
           <CSVLink

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -294,13 +294,13 @@ export const Dashboard = () => {
           }}
         >
           <CSVLink
-            data={csvCourses.filter((e) => e.semester === 'FA22')}
+            data={csvCourses.filter((e) => e.semester === selectedRoster)}
             filename={`export-courses-${Date.now()}`}
           >
             <MenuItem>Export CSV (Courses)</MenuItem>
           </CSVLink>
           <CSVLink
-            data={csvStudents.filter((e) => e.semester === 'FA22')}
+            data={csvStudents.filter((e) => e.semester === selectedRoster)}
             filename={`export-students-${Date.now()}`}
           >
             <MenuItem>Export CSV (Students)</MenuItem>

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -297,7 +297,7 @@ export const Dashboard = () => {
             <MenuItem>Export CSV (Courses)</MenuItem>
           </CSVLink>
           <CSVLink
-            data={csvStudents}
+            data={csvStudents.filter((e) => e.semester === 'FA22')}
             filename={`export-students-${Date.now()}`}
           >
             <MenuItem>Export CSV (Students)</MenuItem>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request makes it so that when you export student data, or course data, as a csv, you will only export the data for this current semester. This is done by filtering out the data to be equal to the current semester


### Test Plan <!-- Required -->

Previously, this is what exporting the courses would look like
![image](https://user-images.githubusercontent.com/64031655/198417616-7d259fbb-ba39-4a9d-8fe4-56ffc76fbb3e.png)

Now, our spring semester for CS2110 is gone
![image](https://user-images.githubusercontent.com/64031655/198417710-0059a821-5187-42d4-8d4e-35c33b7c5d01.png)

The same thing happens for students. Now, only the current semester is displayed
![image](https://user-images.githubusercontent.com/64031655/198417774-cdc5dd49-a88b-457e-a0bc-d71f9a63f119.png)

When creating dummy data, I momentarily changed the source code to randomly select between "FA22" and "SP22" rather than hardcoding in "FA22"

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->

