### PR TITLE
Editing Email Template

### DIFF
--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -53,6 +53,7 @@ export const EditZing = () => {
   /*  Snackbars  */
   const [emailSent, setEmailSent] = useState<boolean>(false)
   const [emailSentError, setEmailSentError] = useState<boolean>(false)
+  const [emailSaved, setEmailSaved] = useState<boolean>(false)
   const emailSentAction = (
     <Button
       variant="text"
@@ -160,6 +161,7 @@ export const EditZing = () => {
           setIsEmailing={setIsEmailing}
           setEmailSent={setEmailSent}
           setEmailSentError={setEmailSentError}
+          setEmailSaved={setEmailSaved}
           courseNames={course.names}
         />
       )}
@@ -306,6 +308,15 @@ export const EditZing = () => {
       >
         <Alert variant="filled" severity="error">
           Emails Failed to send. Please relogin and try again.
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={emailSaved}
+        autoHideDuration={6000}
+        onClose={() => setEmailSaved(false)}
+      >
+        <Alert variant="filled" severity="success">
+          Email Saved
         </Alert>
       </Snackbar>
     </Box>

--- a/frontend/src/modules/EditZing/Components/EmailEdit.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailEdit.tsx
@@ -1,0 +1,58 @@
+import { EmailEditProps } from 'EditZing/Types/ComponentProps'
+import { Button, Box, TextField } from '@mui/material'
+import { SxProps } from '@mui/material'
+
+export const EmailEdit = ({
+  template,
+  replacedHtml,
+  setSelectedTemplate,
+}: EmailEditProps) => {
+  const TitleSx: SxProps = {
+    color: 'essentials.6',
+    backgroundColor: 'essentials.75',
+    borderBottom: '0.5px solid #898992;',
+    border: '0.5px solid',
+    borderColor: 'essentials.50',
+    padding: '16px',
+    fontWeight: '900',
+    borderRadius: '5px 5px 0px 0px;',
+  }
+
+  const copyEmailTemplate = () => {
+    let copied = Object.assign({}, template)
+    copied.html = replacedHtml
+    setSelectedTemplate(copied)
+    console.log('copied', copied)
+    console.log(template)
+  }
+
+  const handleClick = () => {
+    console.log('clicked')
+    copyEmailTemplate()
+  }
+  const SaveButton = () => {
+    return (
+      <Button
+        onClick={() => {
+          handleClick()
+        }}
+        color="secondary"
+        variant="outlined"
+      >
+        Save
+      </Button>
+    )
+  }
+
+  return (
+    <Box>
+      <Box sx={TitleSx}>Email Edit</Box>
+      <TextField
+        multiline={true}
+        defaultValue={replacedHtml}
+        onChange={(event) => (replacedHtml = event.target.value)}
+      />
+      <SaveButton />
+    </Box>
+  )
+}

--- a/frontend/src/modules/EditZing/Components/EmailEdit.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailEdit.tsx
@@ -6,6 +6,7 @@ export const EmailEdit = ({
   template,
   replacedHtml,
   setSelectedTemplate,
+  setEmailSaved,
 }: EmailEditProps) => {
   const TitleSx: SxProps = {
     color: 'essentials.6',
@@ -17,27 +18,33 @@ export const EmailEdit = ({
     fontWeight: '900',
     borderRadius: '5px 5px 0px 0px;',
   }
+  const BodyAndSubjectSx: SxProps = {
+    color: 'essentials.75',
+    backgroundColor: 'essentials.6',
+    border: '0.5px solid',
+    borderBottom: '0.5px solid #898992;',
+    borderColor: 'essentials.50',
+    padding: '16px',
+  }
 
   const copyEmailTemplate = () => {
     let copied = Object.assign({}, template)
     copied.html = replacedHtml
     setSelectedTemplate(copied)
-    console.log('copied', copied)
-    console.log(template)
   }
 
   const handleClick = () => {
-    console.log('clicked')
     copyEmailTemplate()
+    setEmailSaved(true)
   }
   const SaveButton = () => {
     return (
       <Button
+        sx={{ alignSelf: 'end', marginTop: '10px' }}
         onClick={() => {
           handleClick()
         }}
-        color="secondary"
-        variant="outlined"
+        color="primary"
       >
         Save
       </Button>
@@ -46,13 +53,24 @@ export const EmailEdit = ({
 
   return (
     <Box>
-      <Box sx={TitleSx}>Email Edit</Box>
-      <TextField
-        multiline={true}
-        defaultValue={replacedHtml}
-        onChange={(event) => (replacedHtml = event.target.value)}
-      />
-      <SaveButton />
+      <Box>
+        <Box sx={TitleSx}>Email Edit</Box>
+        <TextField
+          sx={{
+            width: '100%',
+            maxHeight: '350px',
+            overflowY: 'scroll',
+            borderRadius: '0px 0px 5px 5px;',
+            ...BodyAndSubjectSx,
+          }}
+          multiline={true}
+          defaultValue={replacedHtml}
+          onChange={(event) => (replacedHtml = event.target.value)}
+        />
+      </Box>
+      <Box display="flex" justifyContent="flex-end">
+        <SaveButton />
+      </Box>
     </Box>
   )
 }

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -1,6 +1,6 @@
 // external imports
 import { useState } from 'react'
-import { Box, Button, Icon, IconButton, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
 import SendIcon from '@mui/icons-material/Send'
 import { useParams } from 'react-router-dom'
 // zing imports

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -1,6 +1,6 @@
 // external imports
 import { useState } from 'react'
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, Icon, IconButton, Typography } from '@mui/material'
 import SendIcon from '@mui/icons-material/Send'
 import { useParams } from 'react-router-dom'
 // zing imports
@@ -10,14 +10,13 @@ import { EmailTemplateButtons } from 'EditZing/Components/EmailTemplateButtons'
 import { EmailPreview } from 'EditZing/Components/EmailPreview'
 import { sendEmail } from 'Emailing/Components/Emailing'
 import { adminSignIn } from '@fire/firebase'
-
+import EditIcon from '@mui/icons-material/Edit'
 // template editor
 import { EmailTemplate } from '@core/Types'
 import { useStudentValue } from '@context/StudentContext'
 import { useCourseValue } from '@context/CourseContext'
 import { useTemplateValue } from '@context/TemplateContext'
 import { EmailEdit } from 'EditZing/Components/EmailEdit'
-
 export const EmailModal = ({
   selectedGroupNumbers,
   selectedStudentEmails,
@@ -25,6 +24,7 @@ export const EmailModal = ({
   setIsEmailing,
   courseNames,
   setEmailSent,
+  setEmailSaved,
   setEmailSentError,
 }: EmailModalProps) => {
   const { courseId } = useParams<{ courseId: string }>()
@@ -159,10 +159,12 @@ export const EmailModal = ({
           onClick={() => {
             setStep(4)
           }}
-          color="secondary"
-          variant="outlined"
+          color="primary"
+          variant="text"
+          sx={{ alignSelf: 'end' }}
         >
-          Edit
+          <EditIcon sx={{ marginRight: '5px' }} />
+          Edit Template
         </Button>
       )
     } else {
@@ -178,6 +180,7 @@ export const EmailModal = ({
           template={selectedTemplate!}
           replacedHtml={replacedHtml}
           setSelectedTemplate={setSelectedTemplate}
+          setEmailSaved={setEmailSaved}
         />
       </Box>
     )
@@ -198,10 +201,17 @@ export const EmailModal = ({
     return (
       <Box>
         <TemplateSelectedComponent />
-        <EmailPreview
-          template={selectedTemplate!}
-          replacedHtml={replacedHtml}
-        />
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+          }}
+        >
+          <EmailPreview
+            template={selectedTemplate!}
+            replacedHtml={replacedHtml}
+          />
+        </Box>
       </Box>
     )
   }
@@ -348,22 +358,31 @@ export const EmailModal = ({
   const SelectTemplates = () => {
     return (
       <>
-        <Typography
-          variant="h5"
-          component="h5"
-          sx={{ display: 'flex', gap: 1 }}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}
         >
-          <Box component="span">To:</Box>
-          <Box
-            component="span"
-            sx={{ fontWeight: 900, maxWidth: '90%', wordBreak: 'break-word' }}
+          <Typography
+            variant="h5"
+            component="h5"
+            sx={{ display: 'flex', gap: 1 }}
           >
-            {selectedGroupNumbers
-              .map((groupNumber) => `Group ${groupNumber}`)
-              .join(', ')}
-            {selectedStudentEmails.join(', ')}
-          </Box>
-        </Typography>
+            <Box component="span">To:</Box>
+            <Box
+              component="span"
+              sx={{ fontWeight: 900, maxWidth: '90%', wordBreak: 'break-word' }}
+            >
+              {selectedGroupNumbers
+                .map((groupNumber) => `Group ${groupNumber}`)
+                .join(', ')}
+              {selectedStudentEmails.join(', ')}
+            </Box>
+          </Typography>
+          {step === 1 && <EditButton />}
+        </Box>
         {step === 0 && <Step0 />}
         {step === 1 && <Step1 />}
       </>
@@ -417,7 +436,6 @@ export const EmailModal = ({
           </Box>
         )}
       </ZingModal.Body>
-      <EditButton />
       <ZingModal.Controls>
         <BackButton />
         <ProceedButton />

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -16,6 +16,7 @@ import { EmailTemplate } from '@core/Types'
 import { useStudentValue } from '@context/StudentContext'
 import { useCourseValue } from '@context/CourseContext'
 import { useTemplateValue } from '@context/TemplateContext'
+import { EmailEdit } from 'EditZing/Components/EmailEdit'
 
 export const EmailModal = ({
   selectedGroupNumbers,
@@ -151,6 +152,36 @@ export const EmailModal = ({
     )
   }
 
+  const EditButton = () => {
+    if (step === 1) {
+      return (
+        <Button
+          onClick={() => {
+            setStep(4)
+          }}
+          color="secondary"
+          variant="outlined"
+        >
+          Edit
+        </Button>
+      )
+    } else {
+      return null
+    }
+  }
+
+  const EditEmail = () => {
+    return (
+      <Box>
+        <TemplateSelectedComponent />
+        <EmailEdit
+          template={selectedTemplate!}
+          replacedHtml={replacedHtml}
+          setSelectedTemplate={setSelectedTemplate}
+        />
+      </Box>
+    )
+  }
   const Step0 = () => {
     return (
       <Box>
@@ -297,6 +328,18 @@ export const EmailModal = ({
           Back to templates
         </Button>
       )
+    } else if (step === 4) {
+      return (
+        <Button
+          onClick={() => {
+            setStep(1)
+          }}
+          color="secondary"
+          variant="outlined"
+        >
+          Back to preview
+        </Button>
+      )
     } else {
       return null
     }
@@ -352,6 +395,7 @@ export const EmailModal = ({
             {step <= 1 && <SelectTemplates />}
             {step === 2 && <StepFailure />}
             {step === 3 && <StepFinalFailure />}
+            {step === 4 && <EditEmail />}
           </Box>
         ) : (
           <Box
@@ -373,6 +417,7 @@ export const EmailModal = ({
           </Box>
         )}
       </ZingModal.Body>
+      <EditButton />
       <ZingModal.Controls>
         <BackButton />
         <ProceedButton />

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -110,3 +110,8 @@ export interface EmailPreviewProps {
   template: EmailTemplate
   replacedHtml: string
 }
+export interface EmailEditProps {
+  template: EmailTemplate
+  replacedHtml: string
+  setSelectedTemplate: (value: EmailTemplate) => void
+}

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -81,6 +81,7 @@ export interface EmailModalProps {
   courseNames: string[]
   setEmailSent: (arg: boolean) => void
   setEmailSentError: (arg: boolean) => void
+  setEmailSaved: (arg: boolean) => void
 }
 
 export interface NotesModalProps {
@@ -114,4 +115,5 @@ export interface EmailEditProps {
   template: EmailTemplate
   replacedHtml: string
   setSelectedTemplate: (value: EmailTemplate) => void
+  setEmailSaved: (arg: boolean) => void
 }


### PR DESCRIPTION
### Summary <!-- Required -->
- added basic functionality for editing email template in the email modal. 
- can click edit button to change the html for the template and then save the new template

This pull request is the first step towards implementing feature to edit emails on email modal

- implemented the basic structure of this feature by adding a textfield and saving the new template
- work in progress: still need to receive designs for this feature and implement the new design 

### Test Plan <!-- Required -->

- testing in progress: tested by printing out the template once the email sent button is clicked and seeing if the changes were saved
- testing both match and no match templates
- testing if the new template is preserved when back button is clicked

