### PR TITLE
Disable match button 2

### DIFF
--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -19,7 +19,6 @@ export const colors = {
   lightgreen: '#CEF5D6',
   darkgreen: '#157E2C',
   darkgray: '#5C5B6A',
-  verylightblack: '#DBDBDD',
 }
 
 // module augmentation, needed for TypeScript

--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -19,6 +19,7 @@ export const colors = {
   lightgreen: '#CEF5D6',
   darkgreen: '#157E2C',
   darkgray: '#5C5B6A',
+  verylightblack: '#DBDBDD',
 }
 
 // module augmentation, needed for TypeScript

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -44,15 +44,18 @@ export const UnmatchedGrid = ({
           <StyledUnmatchedText>
             Unmatched Students ({unmatchedStudents.length})
           </StyledUnmatchedText>
-          <MatchButton label="Match" onClick={handleMatchStudents} />
           <Button
             variant="contained"
             onClick={handleMatchStudents}
             disabled={unmatchedStudents.length < 2}
             sx={{
-              backgroundColor: disabled
-                ? colors.verylightblack
-                : colors.darkgreen,
+              backgroundColor: colors.darkgreen,
+              disabled: {
+                backgroundColor: colors.verylightblack,
+              },
+              '&:hover': {
+                backgroundColor: colors.darkgreen,
+              },
             }}
           >
             Match

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -9,7 +9,6 @@ import {
 } from 'EditZing/Styles/StudentAndGroup.style'
 import { useDrop } from 'react-dnd'
 import { DnDStudentTransferType, STUDENT_TYPE } from 'EditZing/Types/Student'
-import { MatchButton } from './MatchButton'
 import { colors } from '@core/Constants'
 
 /** Where unmatched students live in the grid */

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material'
+import { Box, Button } from '@mui/material'
 import StudentCard from 'EditZing/Components/StudentCard'
 import Grid, { GridSize } from '@mui/material/Grid'
 import { UnmatchedGridProps } from 'EditZing/Types/ComponentProps'
@@ -10,6 +10,7 @@ import {
 import { useDrop } from 'react-dnd'
 import { DnDStudentTransferType, STUDENT_TYPE } from 'EditZing/Types/Student'
 import { MatchButton } from './MatchButton'
+import { colors } from '@core/Constants'
 
 /** Where unmatched students live in the grid */
 export const UnmatchedGrid = ({
@@ -44,6 +45,18 @@ export const UnmatchedGrid = ({
             Unmatched Students ({unmatchedStudents.length})
           </StyledUnmatchedText>
           <MatchButton label="Match" onClick={handleMatchStudents} />
+          <Button
+            variant="contained"
+            onClick={handleMatchStudents}
+            disabled={unmatchedStudents.length < 2}
+            sx={{
+              backgroundColor: disabled
+                ? colors.verylightblack
+                : colors.darkgreen,
+            }}
+          >
+            Match
+          </Button>
         </StyledUnmatchedTextWrapper>
         <Box sx={{ display: 'flex', flexFlow: 'row wrap', gap: '8px' }}>
           {unmatchedStudents.map((student, index) => (

--- a/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
+++ b/frontend/src/modules/EditZing/Components/UnmatchedGrid.tsx
@@ -49,9 +49,6 @@ export const UnmatchedGrid = ({
             disabled={unmatchedStudents.length < 2}
             sx={{
               backgroundColor: colors.darkgreen,
-              disabled: {
-                backgroundColor: colors.verylightblack,
-              },
               '&:hover': {
                 backgroundColor: colors.darkgreen,
               },


### PR DESCRIPTION
### Summary <!-- Required -->

The SQL (sequel) to #110 

This pull request disables the match button when where no groups can be formed (only 0 or 1 unmatched students). It also changes its color to visually show the button is disabled.

- [x] implemented X
- [ ] fixed Y

### Test Plan <!-- Required -->

Initial state: match button is green!
<img width="1512" alt="Screen Shot 2022-11-14 at 7 57 52 PM" src="https://user-images.githubusercontent.com/52147838/201800278-d941c1d0-9df0-4b25-a664-3bba489b6db5.png">

After matching and there are 0 people left to be matched: match button is very light black!
<img width="1512" alt="Screen Shot 2022-11-14 at 7 58 07 PM" src="https://user-images.githubusercontent.com/52147838/201800279-d1245864-a7d6-4843-a363-97bfe7567fd2.png">

When there is 0 or 1 people, then the match button is still very light black because no groups can be formed.
<img width="1512" alt="Screen Shot 2022-11-14 at 7 58 17 PM" src="https://user-images.githubusercontent.com/52147838/201800280-16ba945b-8d26-494e-9ea9-66d14508133b.png">


### Notes <!-- Optional -->

To follow @mluo24's suggestions from the previous PR, I used a regular MUI button instead of a MatchButton (on it's way to depreciation).

### Breaking Changes <!-- Optional -->