### PR TITLE
implemented option to delete groups

### DIFF
--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -28,6 +28,7 @@ export const getAllCourses = async (): Promise<Course[]> => {
             createTime: groupData.createTime.toDate(),
             updateTime: groupData.updateTime.toDate(),
             templateTimestamps: mapDate(groupData.templateTimestamps),
+            hidden: groupData.hidden,
           })),
       }
     })

--- a/backend/functions/src/matching/functions.ts
+++ b/backend/functions/src/matching/functions.ts
@@ -97,6 +97,7 @@ async function makeMatches(courseId: string) {
       createTime: nowDate,
       updateTime: nowDate,
       templateTimestamps: {},
+      hidden: false,
     })
   }
   for (let i = 0; i < groupDoubles.length; i += 2) {
@@ -108,6 +109,7 @@ async function makeMatches(courseId: string) {
       createTime: nowDate,
       updateTime: nowDate,
       templateTimestamps: {},
+      hidden: false,
     })
   }
 
@@ -117,6 +119,7 @@ async function makeMatches(courseId: string) {
     createTime: nowTimestamp,
     updateTime: nowTimestamp,
     templateTimestamps: {}, // Groups have this typed differently though it's just empty object
+    hidden: false,
   }))
 
   // lastly, update the collections to reflect this matching
@@ -319,6 +322,22 @@ async function createEmptyGroup(courseId: string) {
   await Promise.all([groupCreationUpdate, groupNumberUpdate])
 }
 
+async function hideEmptyGroup(courseId: string, groupNumber: number) {
+  await assertIsExistingCourse(courseId)
+
+  const groupToHide = courseRef
+    .doc(courseId)
+    .collection('groups')
+    .doc(groupNumber.toString())
+    .update({ hidden: true })
+    .catch((err) => {
+      console.log(err)
+      throw new Error(`Error in removing group ${groupNumber}`)
+    })
+
+  await Promise.all([groupToHide])
+}
+
 export {
   makeMatches,
   getGroups,
@@ -326,4 +345,5 @@ export {
   transferStudentBetweenGroups,
   createEmptyGroup,
   unmatchStudent,
+  hideEmptyGroup,
 }

--- a/backend/functions/src/matching/routes.ts
+++ b/backend/functions/src/matching/routes.ts
@@ -9,6 +9,7 @@ import {
   transferStudentBetweenGroups,
   createEmptyGroup,
   unmatchStudent,
+  hideEmptyGroup,
 } from './functions'
 
 router.post('/make', (req, res) => {
@@ -88,6 +89,16 @@ router.post('/empty-group', (req, res) => {
 router.post('/transfer/unmatch', (req, res) => {
   const { courseId, studentEmail, groupNumber } = req.body
   unmatchStudent(courseId, groupNumber, studentEmail)
+    .then(() => res.status(200).json({ success: true }))
+    .catch((err) => {
+      console.log(err)
+      res.status(400).json({ success: false, err: err.message })
+    })
+})
+
+router.post('/hide-group', (req, res) => {
+  const { courseId, groupNumber } = req.body
+  hideEmptyGroup(courseId, groupNumber)
     .then(() => res.status(200).json({ success: true }))
     .catch((err) => {
       console.log(err)

--- a/backend/functions/src/types/index.ts
+++ b/backend/functions/src/types/index.ts
@@ -24,6 +24,7 @@ export type Group = {
   createTime: Date
   updateTime: Date
   templateTimestamps: { [key: string]: Date }
+  hidden: boolean
 }
 
 /** Student data. This is not exactly how it's stored in the database, since
@@ -104,4 +105,5 @@ export type FirestoreGroup = {
   createTime: Timestamp
   updateTime: Timestamp
   templateTimestamps: EmailTimestamps
+  hidden: boolean
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import { getDownloadURL, ref } from 'firebase/storage'
 import axios, { AxiosResponse } from 'axios'
 import { CourseProvider, StudentProvider } from '@context'
 import { TemplateProvider } from '@context/TemplateContext'
+import { Groups } from '@mui/icons-material'
 
 const App = () => {
   const [currentUser, setCurrentUser] = useState<User | null>(null)
@@ -514,6 +515,25 @@ const App = () => {
       },
     ])
 
+  // update whats shown on the frontend
+  const removeGroups = (courseId: string, groupNumber: number) => {
+    setCourses(
+      courses.map((course) =>
+        course.courseId === courseId
+          ? {
+              ...course,
+              unmatched: [...course.unmatched],
+              groups: course.groups.map((group) =>
+                groupNumber === group.groupNumber
+                  ? { ...group, hidden: true }
+                  : group
+              ),
+            }
+          : course
+      )
+    )
+  }
+
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
@@ -533,6 +553,7 @@ const App = () => {
                 moveStudent,
                 matchStudents,
                 addGroupEmailTimestamps,
+                removeGroups,
               }}
             >
               <StudentProvider

--- a/frontend/src/context/CourseContext.tsx
+++ b/frontend/src/context/CourseContext.tsx
@@ -17,6 +17,7 @@ interface CourseContextType {
     templateId: string,
     timestamp: Date
   ) => void
+  removeGroups: (courseId: string, groupNumber: number) => void
 }
 
 const CourseContext = React.createContext<CourseContextType>({
@@ -25,6 +26,7 @@ const CourseContext = React.createContext<CourseContextType>({
   moveStudent: () => {},
   matchStudents: async () => {},
   addGroupEmailTimestamps: () => {},
+  removeGroups: () => {},
 } as CourseContextType)
 
 export function CourseProvider({

--- a/frontend/src/modules/Core/Types/Course.ts
+++ b/frontend/src/modules/Core/Types/Course.ts
@@ -17,6 +17,7 @@ export interface Group {
   createTime: Date
   updateTime: Date
   templateTimestamps: { [key: string]: Date }
+  hidden: boolean
 }
 
 export interface ResponseCourse {
@@ -36,6 +37,7 @@ export interface ResponseGroup {
   createTime: string
   updateTime: string
   templateTimestamps: { [key: string]: string }
+  hidden: boolean
 }
 
 export const responseGroupToGroup = (group: ResponseGroup): Group => ({
@@ -43,6 +45,7 @@ export const responseGroupToGroup = (group: ResponseGroup): Group => ({
   createTime: new Date(group.createTime),
   updateTime: new Date(group.updateTime),
   templateTimestamps: responseTimestampsToDate(group.templateTimestamps),
+  hidden: group.hidden,
 })
 
 export const responseCourseToCourse = (course: ResponseCourse): Course => ({

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -276,31 +276,33 @@ export const EditZing = () => {
                 updateNotes={updateNotes}
               />
             </Box>
-            {copyStudentGroups.map((studentGroup) => (
-              <GroupCard
-                key={studentGroup.groupNumber}
-                courseId={courseId}
-                studentList={getStudentsFromEmails(studentGroup.members)}
-                groupNumber={studentGroup.groupNumber}
-                templateMap={templateNameMap}
-                groupTimestamps={studentGroup.templateTimestamps}
-                moveStudent={moveStudent}
-                createTime={studentGroup.createTime}
-                updateTime={studentGroup.updateTime}
-                selected={selectedGroupNumbers.includes(
-                  studentGroup.groupNumber
-                )}
-                selectedStudents={selectedStudentEmails}
-                handleChecked={(event) => {
-                  editSelectedGroupNumbers(
-                    studentGroup.groupNumber,
-                    event.target.checked
-                  )
-                }}
-                handleAddStudent={editSelectedStudentEmails}
-                updateNotes={updateNotes}
-              />
-            ))}
+            {copyStudentGroups
+              .filter((e) => !e.hidden)
+              .map((studentGroup) => (
+                <GroupCard
+                  key={studentGroup.groupNumber}
+                  courseId={courseId}
+                  studentList={getStudentsFromEmails(studentGroup.members)}
+                  groupNumber={studentGroup.groupNumber}
+                  templateMap={templateNameMap}
+                  groupTimestamps={studentGroup.templateTimestamps}
+                  moveStudent={moveStudent}
+                  createTime={studentGroup.createTime}
+                  updateTime={studentGroup.updateTime}
+                  selected={selectedGroupNumbers.includes(
+                    studentGroup.groupNumber
+                  )}
+                  selectedStudents={selectedStudentEmails}
+                  handleChecked={(event) => {
+                    editSelectedGroupNumbers(
+                      studentGroup.groupNumber,
+                      event.target.checked
+                    )
+                  }}
+                  handleAddStudent={editSelectedStudentEmails}
+                  updateNotes={updateNotes}
+                />
+              ))}
           </Box>
         </DndProvider>
       </Box>

--- a/frontend/src/modules/EditZing/Components/EditZing.tsx
+++ b/frontend/src/modules/EditZing/Components/EditZing.tsx
@@ -35,7 +35,7 @@ export const EditZing = () => {
   const { courseId } = useParams<{ courseId: string }>()
   const history = useHistory()
   const state = history.location.state as any
-  const { courses, moveStudent, matchStudents } = useCourseValue()
+  const { courses, moveStudent, matchStudents, removeGroups } = useCourseValue()
   const { students, updateNotes } = useStudentValue()
   const { templates } = useTemplateValue()
 
@@ -301,6 +301,7 @@ export const EditZing = () => {
                   }}
                   handleAddStudent={editSelectedStudentEmails}
                   updateNotes={updateNotes}
+                  removeGroups={removeGroups}
                 />
               ))}
           </Box>

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -6,7 +6,7 @@ import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
 import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
 import { Box, Tooltip, Checkbox, IconButton } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
-import { Delete, DeleteOutline } from '@mui/icons-material'
+import { Delete } from '@mui/icons-material'
 import axios from 'axios'
 import { API_ROOT, MATCHING_API } from '@core'
 

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -24,6 +24,7 @@ const GroupCard = ({
   handleChecked,
   handleAddStudent,
   updateNotes,
+  removeGroups,
 }: GroupGridProps) => {
   /**
    * Helper to format the timestamp data in a way that is helpful for displaying in tooltips
@@ -68,12 +69,12 @@ const GroupCard = ({
     setIsHovering(false)
   }
 
-  const removeGroup = (groupId: string, groupNumber: number) => {
+  const removeGroup = (courseId: string, groupNumber: number) => {
     axios.post(`${API_ROOT}${MATCHING_API}/hide-group`, {
       courseId: courseId,
       groupNumber: groupNumber,
     })
-    window.location.reload() // this can be improved so page doesn't reloadA
+    removeGroups(courseId, groupNumber)
   }
 
   return (

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -4,8 +4,11 @@ import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
 import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
-import { Box, Tooltip, Checkbox } from '@mui/material'
+import { Box, Tooltip, Checkbox, IconButton } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
+import { Delete, DeleteOutline } from '@mui/icons-material'
+import axios from 'axios'
+import { API_ROOT, MATCHING_API } from '@core'
 
 /** the equivalent of Column */
 const GroupCard = ({
@@ -63,6 +66,14 @@ const GroupCard = ({
 
   const handleMouseOut = () => {
     setIsHovering(false)
+  }
+
+  const removeGroup = (groupId: string, groupNumber: number) => {
+    axios.post(`${API_ROOT}${MATCHING_API}/hide-group`, {
+      courseId: courseId,
+      groupNumber: groupNumber,
+    })
+    window.location.reload() // this can be improved so page doesn't reloadA
   }
 
   return (
@@ -123,12 +134,30 @@ const GroupCard = ({
             )
           })}
           <Box flexGrow={2} />
+          <IconButton
+            color="secondary"
+            sx={{
+              display: studentList.length === 0 && isHovering ? 'flex' : 'none',
+              backgroundColor: 'transparent',
+              border: 'none',
+            }}
+            onClick={() => {
+              if (studentList.length === 0) {
+                removeGroup(courseId, groupNumber)
+              }
+            }}
+          >
+            <Delete sx={{ color: 'purple' }}></Delete>
+          </IconButton>
           <Checkbox
             color="secondary"
             checked={selected}
             onChange={handleChecked}
             sx={{
-              display: selected || isHovering ? 'flex' : 'none',
+              display:
+                selected || (studentList.length !== 0 && isHovering)
+                  ? 'flex'
+                  : 'none',
             }}
           />
         </Box>

--- a/frontend/src/modules/EditZing/Types/ComponentProps.ts
+++ b/frontend/src/modules/EditZing/Types/ComponentProps.ts
@@ -41,6 +41,7 @@ export interface GroupGridProps {
   updateTime: Date
   selected: boolean
   selectedStudents: string[]
+  removeGroups: (courseId: string, groupNumber: number) => void
   handleChecked: (event: React.ChangeEvent<HTMLInputElement>) => void
   handleAddStudent: (student: string, selected: boolean) => void
   updateNotes: (
@@ -109,4 +110,9 @@ export interface EmailModalContentProps {
 export interface EmailPreviewProps {
   template: EmailTemplate
   replacedHtml: string
+}
+
+export interface DeleteGroupProps {
+  open: boolean
+  handleClose: () => void
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This change gives users the ability to delete empty groups (although the group will still exist, it just will not be shown to user)

- [x] Change database to take into account a new field `hidden`
- [x] Frontend only displays groups with `hidden` field of `false`
- [x] Backend implementation to handle changes with `hidden`
- [x] Styling with the garbage can and checkbox depending on the population of group

https://user-images.githubusercontent.com/64031655/202386745-32e5df48-bdc6-4ed4-90e8-d66b05ab6478.mp4

### Test Plan <!-- Required -->

Principles of test driven development (TDD) was used throughout the implementation of this feature because there was a lot of different parts of the code base that needed editing. This is roughly the sequence that each feature was developed as well. 

1. Testing of the `hidden` field (from changing type definitions) was done by simply looking at the database
2. We wanted only groups with `{ hidden: false }` to show up. This was tested by manually changing the field in the database, and seeing whether that group appears in the course page
3. After the backend helper function `hideEmptyGroup` and it's associated endpoint `matching/hide-group` was written, this was tested by making API calls using Insomnia, and observing whether a group's `hidden` state switched from `false` to `true`.
4. Integration with the backend to the frontend was mainly done through visual testing (see video above) 

### Notes <!-- Optional -->

- We probably don't want the page to fully reload every time a group had been deleted
- Definitely should add a confirmation button to confirm deleting a group
- Axios, `API_ROOT`, and `MATCHING_API` are all called in `GroupCard.tsx`. Scanning the other parts of the database, the majority of API calls are written in `App.tsx`. However I suspect that was because we wanted to centralize the movement of students for the entire codebase. In addition, I don't expect the added backend functions and endpoints to be called anywhere else but `GroupCard.tsx`, which is why I choose to put it there instead. 
- There's also a deploy to Firebase test that is failing, probably because we've changed the contents of the firebase.

### Breaking Changes <!-- Optional -->

The majority of breaking changes are where types are defined. There were quite a number of types that needed to be changed in order for this feature to work properly.
- In `./backend/functions/src/matching/functions.ts`, `groupCreationUpdate`, `newGroup`, `newGroups`, `newGroupsFirestore` added an additional field `hidden: false` to initialize a new group as not being hidden
- In `./backend/functions/src/types/index.ts`, types needed to be changed. `Group`, and `FirestoreGroup` were updated to have `hidden: boolean`
- In `./backend/functions/src/course/functions/ts`, `getAllCourses` was changed so that `groups` in `courseData` will also allow us to access `hidden`
