### PR TITLE
Fixed Calculating Overall Stats for Metrics Page

### DIFF
--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -15,15 +15,21 @@ export const Metrics = () => {
   const { courses } = useCourseValue()
   const { students } = useStudentValue()
 
-  function isDateInThisWeek(date: Date) {
+  //checks if date is within the week (beginning of the day Sunday to end of day Saturday)
+  const isDateInThisWeek = (date: Date) => {
     const todayObj = new Date()
     const todayDate = todayObj.getDate()
     const todayDay = todayObj.getDay()
+    //set the date to be Sunday midnight
+    todayObj.setDate(todayDate - todayDay)
+    todayObj.setHours(0, 0, 0, 0)
     // get first date of week
-    const firstDayOfWeek = new Date(todayObj.setDate(todayDate - todayDay))
+    const firstDayOfWeek = new Date(todayObj)
     // get last date of week
     const lastDayOfWeek = new Date(firstDayOfWeek)
+    //set the date to be Saturday 11:59:59 PM
     lastDayOfWeek.setDate(lastDayOfWeek.getDate() + 6)
+    lastDayOfWeek.setHours(23, 59, 999)
     // if date is equal or within the first and last dates of the week
     return date >= firstDayOfWeek && date <= lastDayOfWeek
   }

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -47,6 +47,7 @@ export const Metrics = () => {
 
   const [selectedRoster, setSelectedRoster] = useState<string>('SP23')
 
+  //group student's classes under the student
   const studentsInSemester = new Map<
     string,
     { semester: string; groups: GroupMembership[]; college: string }
@@ -71,7 +72,6 @@ export const Metrics = () => {
                 college: student.college,
               })
             }
-
             return {
               semester: course.roster,
               cornellEmail: student.email,

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -43,11 +43,11 @@ export const Metrics = () => {
     )
   )
   const uniqueStudentsInWeek = []
-  for (let i = 0; i < numStudentsInWeek.length; i++) {
-    if (numStudentsInWeek[i].length === students[i].groups.length) {
+  numStudentsInWeek.forEach((student, i) => {
+    if (student.length === students[i].groups.length) {
       uniqueStudentsInWeek.push(students[i])
     }
-  }
+  })
   //calculate number of unique students who have made requests
   const numStudents = {
     number: students.length,
@@ -57,7 +57,6 @@ export const Metrics = () => {
     showAdded: true,
   }
   const coursesInWeek: string[] = []
-
   numStudentsInWeek.forEach((member) => {
     member.forEach((memberships) => {
       if (coursesInWeek.indexOf(memberships.courseId) === -1) {
@@ -65,6 +64,7 @@ export const Metrics = () => {
       }
     })
   })
+
   //calculate number of unique courses that have received requests
   const numCourses = {
     number: courses.length,

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -36,12 +36,18 @@ export const Metrics = () => {
       isDateInThisWeek(membership.submissionTime)
     )
   )
+  const uniqueStudentsInWeek = []
+  for (let i = 0; i < numStudentsInWeek.length; i++) {
+    if (numStudentsInWeek[i].length === students[i].groups.length) {
+      uniqueStudentsInWeek.push(students[i])
+    }
+  }
   //calculate number of unique students who have made requests
   const numStudents = {
     number: students.length,
     title: 'UNIQUE STUDENTS',
     subtitle: 'made requests',
-    thisWeek: numStudentsInWeek.length,
+    thisWeek: uniqueStudentsInWeek.length,
     showAdded: true,
   }
   const coursesInWeek: string[] = []


### PR DESCRIPTION
### Summary <!-- Required -->

Fixed calculating overall stats so that they only show for the chosen semester. Modified IsDateInWeek function so that it calculates the week from beginning of the day Sunday to end of day Saturday.

### Test Plan <!-- Required -->
Tested by changing the timestamp for the student submission time for that course on firebase emulator. 

In the screenshot, there are only 8 unique students added for this week because this statistic is calculated based on when the student submitted the first survey request. 

<!-- Provide screenshots or point out the additional unit tests -->
<img width="1154" alt="Screenshot 2022-12-08 at 4 44 35 PM" src="https://user-images.githubusercontent.com/94809605/206573828-92f590bb-5d5a-49ce-8e66-d420070195b3.png">
<img width="1281" alt="Screenshot 2022-12-08 at 4 43 59 PM" src="https://user-images.githubusercontent.com/94809605/206573875-59551a2d-2022-480f-8d6b-1a8e17931870.png">
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
- Database schema change (anything that changes Firestore collection structure)
- Other change that could cause problems (Detailed in notes)

