### PR TITLE
New filter: Can Add to Existing Group

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -22,6 +22,7 @@ type FilterOption =
   | 'unmatchable'
   | 'newly-matchable'
   | 'matchable'
+  | 'can-add-to-existing-group'
   | 'no-check-in-email'
   | 'no-no-match-email'
 
@@ -33,6 +34,7 @@ const filterOptionDisplay = [
   ['unmatchable', 'Unmatchable'],
   ['newly-matchable', 'Newly Matchable'],
   ['matchable', 'Matchable'],
+  ['can-add-to-existing-group', 'Can Add to Existing group'],
   ['no-check-in-email', 'No Check In Email'],
   ['no-no-match-email', 'No No Match Email'],
 ]
@@ -99,6 +101,11 @@ export const Dashboard = () => {
           (course, _) =>
             (course.lastGroupNumber > 0 && course.unmatched.length > 0) ||
             (course.lastGroupNumber === 0 && course.unmatched.length > 1)
+        )
+      case 'can-add-to-existing-group':
+        return [...courseInfo].filter(
+          (course, _) =>
+            course.lastGroupNumber > 0 && course.unmatched.length === 1
         )
       case 'no-check-in-email':
         return courseInfo.filter(hasUnsentCheckIns)

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -16,6 +16,7 @@ import { useHistory } from 'react-router-dom'
 import { AccountMenu } from 'Dashboard/Components/AccountMenu'
 import ClearIcon from '@mui/icons-material/Clear'
 type SortOrder = 'newest-requests-first' | 'classes-a-z' | 'classes-z-a'
+
 type FilterOption =
   | 'no-filter'
   | 'unmatchable'


### PR DESCRIPTION
### Summary <!-- Required -->
Created a new filter for classes called "Can Add to Existing Group." This filter is for when we have at least one existing group and exactly one unmatched student, so we can add them to an already existing group. 

### Test Plan <!-- Required -->

As seen below, the new filter shows up correctly and contains all classes that fit the above description.


https://user-images.githubusercontent.com/100158738/206579675-52623fcf-aad2-4474-8107-fabe428fcaa6.mov