### PR TITLE
Loading for signing in

### DIFF
--- a/frontend/src/modules/AdminHome/Components/AdminHome.tsx
+++ b/frontend/src/modules/AdminHome/Components/AdminHome.tsx
@@ -78,7 +78,9 @@ export const AdminHome = () => {
           }}
           onClick={() => {
             handleSigninClick()
-            adminSignIn().catch(() => {})
+            adminSignIn().catch(() => {
+              setLoading(false)
+            })
           }}
         >
           LSC Admin Login

--- a/frontend/src/modules/AdminHome/Components/AdminHome.tsx
+++ b/frontend/src/modules/AdminHome/Components/AdminHome.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 
 export const AdminHome = () => {
   const [isLoading, setLoading] = React.useState(false)
-  function handleLoginClick() {
+  function handleSigninClick() {
     setLoading(true)
   }
   return (
@@ -68,16 +68,17 @@ export const AdminHome = () => {
         </Typography>
         <LoadingButton
           loading={isLoading}
-          color="secondary"
+          color={isLoading ? undefined : 'secondary'}
           variant="outlined"
           sx={{
+            backgroundColor: 'white',
             width: '14em',
             fontSize: '22px',
             mb: '1.25em',
           }}
           onClick={() => {
-            handleLoginClick()
-            adminSignIn().catch(() => {})
+            handleSigninClick()
+            // adminSignIn().catch(() => { })
           }}
         >
           LSC Admin Login

--- a/frontend/src/modules/AdminHome/Components/AdminHome.tsx
+++ b/frontend/src/modules/AdminHome/Components/AdminHome.tsx
@@ -78,7 +78,7 @@ export const AdminHome = () => {
           }}
           onClick={() => {
             handleSigninClick()
-            // adminSignIn().catch(() => { })
+            adminSignIn().catch(() => {})
           }}
         >
           LSC Admin Login

--- a/frontend/src/modules/AdminHome/Components/AdminHome.tsx
+++ b/frontend/src/modules/AdminHome/Components/AdminHome.tsx
@@ -1,11 +1,17 @@
 import { StyledBackground } from 'Home/Styles/Home.style'
 import { adminSignIn } from '@fire'
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import matchimg from '@assets/img/matching.svg'
 
 import { ReactComponent as CornellSeal } from '@assets/img/CornellSealWhite.svg'
+import { LoadingButton } from '@mui/lab'
+import React from 'react'
 
 export const AdminHome = () => {
+  const [isLoading, setLoading] = React.useState(false)
+  function handleLoginClick() {
+    setLoading(true)
+  }
   return (
     <StyledBackground>
       <Box
@@ -60,7 +66,8 @@ export const AdminHome = () => {
           Connect students. <br />
           Create groups.
         </Typography>
-        <Button
+        <LoadingButton
+          loading={isLoading}
           color="secondary"
           variant="outlined"
           sx={{
@@ -69,11 +76,12 @@ export const AdminHome = () => {
             mb: '1.25em',
           }}
           onClick={() => {
+            handleLoginClick()
             adminSignIn().catch(() => {})
           }}
         >
           LSC Admin Login
-        </Button>
+        </LoadingButton>
       </Box>
       <Box
         sx={{


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request changes the admin login button to visually show the user that their login request is being handled by using a LoadingButton.

- [x] implemented X
- [ ] fixed Y

### Test Plan <!-- Required -->

Before clicking signin button.
<img width="1512" alt="Screen Shot 2022-12-09 at 8 57 36 PM" src="https://user-images.githubusercontent.com/52147838/206823213-e93a72ed-7044-4725-a759-b665e4fa347c.png">

While signin button is clicked and the request is being handled. There is a little spinny thing.
<img width="1512" alt="Screen Shot 2022-12-09 at 8 57 40 PM" src="https://user-images.githubusercontent.com/52147838/206823214-282b0328-3fb7-4145-a676-c18474f39c9d.png">

### Notes <!-- Optional -->

I changed the button color when loading to white from grey, to be more in line with the theme of Zing. I don't think there is a loading button in the design but correct me if I am wrong.

### Breaking Changes <!-- Optional -->

Nothing.