### PR TITLE
Standardize Zing-LSC Theme

### DIFF
--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -304,6 +304,25 @@ theme = createTheme(theme, {
         },
       },
     },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          transition: 'box-shadow 0.1s',
+        },
+        elevation1: {
+          boxShadow: '0px 2px 5px rgba(205, 156, 242, 0.2)',
+        },
+        elevation2: {
+          boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.07)',
+        },
+        elevation3: {
+          boxShadow: '4px 4px 8px rgba(0, 0, 0, 0.3)',
+        },
+        elevation4: {
+          boxShadow: '4px 4px 10px rgba(0, 0, 0, 0.3)',
+        },
+      },
+    },
   },
 })
 

--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -294,6 +294,16 @@ theme = createTheme(theme, {
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: theme.palette.essentials.main,
+          color: 'white',
+          fontWeight: 600,
+          borderRadius: '10px',
+        },
+      },
+    },
   },
 })
 

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -119,16 +119,6 @@ const GroupCard = ({
                 key={index}
                 title={`${timestamp.name + ': ' + month}/${day}`}
                 placement="bottom-start"
-                componentsProps={{
-                  tooltip: {
-                    sx: {
-                      bgcolor: 'essentials.main',
-                      color: 'white',
-                      fontWeight: 600,
-                      borderRadius: '10px',
-                    },
-                  },
-                }}
               >
                 <CircleIcon sx={{ fontSize: 10 }} color="primary" />
               </Tooltip>

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -4,7 +4,7 @@ import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
 import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
-import { Box, Tooltip, Checkbox, IconButton } from '@mui/material'
+import { Box, Tooltip, Paper, Checkbox, IconButton } from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 import { Delete } from '@mui/icons-material'
 import axios from 'axios'
@@ -78,102 +78,100 @@ const GroupCard = ({
   }
 
   return (
-    <Box>
-      <Box
-        onMouseOver={handleMouseOver}
-        onMouseOut={handleMouseOut}
-        ref={drop}
-        sx={{
-          width: '380px',
-          height: '350px',
-          padding: '2rem',
-          border: 0.5,
-          borderColor: selected || isHovering ? 'purple.50' : 'purple.16',
-          boxShadow:
-            !selected && isHovering
-              ? '4px 4px 10px rgba(0, 0, 0, 0.3)'
-              : '0px 4px 10px rgba(0, 0, 0, 0.07)',
-          borderRadius: '20px',
-          margin: '0.25rem',
-          backgroundColor: selected ? 'rgba(129, 94, 212, 0.15);' : 'white',
-          opacity: isOver ? '0.6' : '1',
-          transition: 'box-shadow 0.1s',
-        }}
-      >
-        <Box display="flex" alignItems="center" sx={{ mb: 2, height: '42px' }}>
-          <Tooltip
-            title={
-              'Created on ' +
-              (createTime.getMonth() + 1) +
-              '/' +
-              createTime.getDate()
-            }
-          >
-            <StyledGroupText>{`Group ${groupNumber}`}</StyledGroupText>
-          </Tooltip>
-          {tooltipTimestamps.map((timestamp, index) => {
-            const month = timestamp.timestamp.getMonth() + 1
-            const day = timestamp.timestamp.getDate()
-            return (
-              <Tooltip
-                key={index}
-                title={`${timestamp.name + ': ' + month}/${day}`}
-                placement="bottom-start"
-              >
-                <CircleIcon sx={{ fontSize: 10 }} color="primary" />
-              </Tooltip>
-            )
-          })}
-          <Box flexGrow={2} />
-          <IconButton
-            color="secondary"
-            sx={{
-              display: studentList.length === 0 && isHovering ? 'flex' : 'none',
-              backgroundColor: 'transparent',
-              border: 'none',
-            }}
-            onClick={() => {
-              if (studentList.length === 0) {
-                removeGroup(courseId, groupNumber)
-              }
-            }}
-          >
-            <Delete sx={{ color: 'purple' }}></Delete>
-          </IconButton>
-          <Checkbox
-            color="secondary"
-            checked={selected}
-            onChange={handleChecked}
-            sx={{
-              display:
-                selected || (studentList.length !== 0 && isHovering)
-                  ? 'flex'
-                  : 'none',
-            }}
-          />
-        </Box>
-        <Box
+    <Paper
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
+      ref={drop}
+      sx={{
+        width: '380px',
+        height: '350px',
+        padding: '2rem',
+        border: 0.5,
+        borderColor: selected || isHovering ? 'purple.50' : 'purple.16',
+        boxShadow:
+          !selected && isHovering
+            ? '4px 4px 10px rgba(0, 0, 0, 0.3)'
+            : '0px 4px 10px rgba(0, 0, 0, 0.07)',
+        borderRadius: '20px',
+        margin: '0.25rem',
+        backgroundColor: selected ? 'rgba(129, 94, 212, 0.15);' : 'white',
+        opacity: isOver ? '0.6' : '1',
+        transition: 'box-shadow 0.1s',
+      }}
+    >
+      <Box display="flex" alignItems="center" sx={{ mb: 2, height: '42px' }}>
+        <Tooltip
+          title={
+            'Created on ' +
+            (createTime.getMonth() + 1) +
+            '/' +
+            createTime.getDate()
+          }
+        >
+          <StyledGroupText>{`Group ${groupNumber}`}</StyledGroupText>
+        </Tooltip>
+        {tooltipTimestamps.map((timestamp, index) => {
+          const month = timestamp.timestamp.getMonth() + 1
+          const day = timestamp.timestamp.getDate()
+          return (
+            <Tooltip
+              key={index}
+              title={`${timestamp.name + ': ' + month}/${day}`}
+              placement="bottom-start"
+            >
+              <CircleIcon sx={{ fontSize: 10 }} color="primary" />
+            </Tooltip>
+          )
+        })}
+        <Box flexGrow={2} />
+        <IconButton
+          color="secondary"
           sx={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(112px, max-content))',
-            gap: '16px',
+            display: studentList.length === 0 && isHovering ? 'flex' : 'none',
+            backgroundColor: 'transparent',
+            border: 'none',
+          }}
+          onClick={() => {
+            if (studentList.length === 0) {
+              removeGroup(courseId, groupNumber)
+            }
           }}
         >
-          {studentList.map((student, index) => (
-            <StudentCard
-              key={index}
-              courseId={courseId}
-              groupNumber={groupNumber}
-              student={student}
-              templateMap={templateMap}
-              selected={selectedStudents.includes(student.email)}
-              handleAddStudent={handleAddStudent}
-              updateNotes={updateNotes}
-            />
-          ))}
-        </Box>
+          <Delete sx={{ color: 'purple' }}></Delete>
+        </IconButton>
+        <Checkbox
+          color="secondary"
+          checked={selected}
+          onChange={handleChecked}
+          sx={{
+            display:
+              selected || (studentList.length !== 0 && isHovering)
+                ? 'flex'
+                : 'none',
+          }}
+        />
       </Box>
-    </Box>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(112px, max-content))',
+          gap: '16px',
+        }}
+      >
+        {studentList.map((student, index) => (
+          <StudentCard
+            key={index}
+            courseId={courseId}
+            groupNumber={groupNumber}
+            student={student}
+            templateMap={templateMap}
+            selected={selectedStudents.includes(student.email)}
+            handleAddStudent={handleAddStudent}
+            updateNotes={updateNotes}
+          />
+        ))}
+      </Box>
+    </Paper>
   )
 }
 

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -10,6 +10,11 @@ import { Delete } from '@mui/icons-material'
 import axios from 'axios'
 import { API_ROOT, MATCHING_API } from '@core'
 
+export interface ExtendedPaperProps {
+  exact?: boolean
+  to?: string
+}
+
 /** the equivalent of Column */
 const GroupCard = ({
   courseId,
@@ -82,21 +87,17 @@ const GroupCard = ({
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
       ref={drop}
+      elevation={isHovering && !selected ? 4 : 2}
       sx={{
         width: '380px',
         height: '350px',
         padding: '2rem',
         border: 0.5,
         borderColor: selected || isHovering ? 'purple.50' : 'purple.16',
-        boxShadow:
-          !selected && isHovering
-            ? '4px 4px 10px rgba(0, 0, 0, 0.3)'
-            : '0px 4px 10px rgba(0, 0, 0, 0.07)',
         borderRadius: '20px',
         margin: '0.25rem',
         backgroundColor: selected ? 'rgba(129, 94, 212, 0.15);' : 'white',
         opacity: isOver ? '0.6' : '1',
-        transition: 'box-shadow 0.1s',
       }}
     >
       <Box display="flex" alignItems="center" sx={{ mb: 2, height: '42px' }}>

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -10,11 +10,6 @@ import { Delete } from '@mui/icons-material'
 import axios from 'axios'
 import { API_ROOT, MATCHING_API } from '@core'
 
-export interface ExtendedPaperProps {
-  exact?: boolean
-  to?: string
-}
-
 /** the equivalent of Column */
 const GroupCard = ({
   courseId,

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -1,16 +1,16 @@
 import { useState } from 'react'
-import Paper from '@mui/material/Paper'
 import { STUDENT_TYPE } from 'EditZing/Types/Student'
 import { StudentGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrag } from 'react-dnd'
-import Tooltip from '@mui/material/Tooltip'
 import {
   Checkbox,
   Box,
+  Tooltip,
   Typography,
   Snackbar,
   IconButton,
   SvgIcon,
+  Paper,
 } from '@mui/material'
 import NotesModal from './NotesModal'
 import { ReactComponent as FilledEditIcon } from '@assets/img/FilledEditIcon.svg'

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -191,16 +191,6 @@ const StudentCard = ({
                     key={index}
                     title={`${timestamp.name + ': ' + month}/${day}`}
                     placement="bottom-start"
-                    componentsProps={{
-                      tooltip: {
-                        sx: {
-                          bgcolor: 'essentials.main',
-                          color: 'white',
-                          fontWeight: 600,
-                          borderRadius: '10px',
-                        },
-                      },
-                    }}
                   >
                     <CircleIcon sx={{ fontSize: 10 }} color="primary" />
                   </Tooltip>

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -134,6 +134,7 @@ const StudentCard = ({
           onMouseOver={() => setIsHovering(true)}
           onMouseOut={() => setIsHovering(false)}
           style={{ opacity: opacity }}
+          elevation={isHovering && !selected ? 3 : 1}
           sx={{
             padding: '11px 12px',
             background: selected ? 'rgba(213, 204, 230, .85)' : '#FBF9FF',
@@ -141,13 +142,8 @@ const StudentCard = ({
             fontFamily: 'Montserrat',
             fontWeight: '700',
             fontSize: '14',
-            boxShadow:
-              isHovering && !selected
-                ? '4px 4px 8px rgba(0, 0, 0, 0.3)'
-                : '0px 2px 5px rgba(205, 156, 242, 0.2)',
             borderRadius: '10px',
             width: '100%',
-            transition: 'box-shadow 0.1s',
           }}
         >
           <Box


### PR DESCRIPTION
### 
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request standardizes parts of Zing-LSC's theme to make styling easier.

- [x] Standardize tooltip appearance
- [x] Standardize hover shadows for student and group cards

### Test Plan <!-- Required -->

Testing was performed by running the application locally and verifying that there were no visual irregularities due to standardizing the styling.

Standardized Tooltips:
<img width="403" alt="Screenshot 2022-12-14 at 2 03 34 PM" src="https://user-images.githubusercontent.com/45516888/207689355-ddb2959a-5cf7-48e9-a7f3-be852a50d1a8.png">

