### PR TITLE
Change roster to WI23

### DIFF
--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -82,7 +82,7 @@ export const addStudentSurveyResponse = async (
   year: string,
   courseCatalogNames: string[]
 ) => {
-  const roster = 'WI22' // Winter 2022
+  const roster = 'WI23' // Winter 2023
 
   // 0. Check if email is valid cornell.edu email.
   const emailRegex = /^\w+@cornell.edu$/

--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -82,7 +82,7 @@ export const addStudentSurveyResponse = async (
   year: string,
   courseCatalogNames: string[]
 ) => {
-  const roster = 'FA22' // Fall 2022
+  const roster = 'WI22' // Winter 2022
 
   // 0. Check if email is valid cornell.edu email.
   const emailRegex = /^\w+@cornell.edu$/

--- a/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
+++ b/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
@@ -173,8 +173,8 @@ export const AccountMenu = ({
           Summer 2022
         </MenuItem>
         <MenuItem onClick={() => setSelectedRoster('FA22')}>Fall 2022</MenuItem>
-        <MenuItem onClick={() => setSelectedRoster('WI22')}>
-          Winter 2022
+        <MenuItem onClick={() => setSelectedRoster('WI23')}>
+          Winter 2023
         </MenuItem>
         <MenuItem onClick={() => setSelectedRoster('SP23')}>
           Spring 2023

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -161,7 +161,7 @@ export const Dashboard = () => {
     })
   }
 
-  const [selectedRoster, setSelectedRoster] = useState<string>('FA22')
+  const [selectedRoster, setSelectedRoster] = useState<string>('WI22')
 
   const [query, setQuery] = useState('')
 

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -161,7 +161,7 @@ export const Dashboard = () => {
     })
   }
 
-  const [selectedRoster, setSelectedRoster] = useState<string>('WI22')
+  const [selectedRoster, setSelectedRoster] = useState<string>('WI23')
 
   const [query, setQuery] = useState('')
 

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -152,7 +152,7 @@ export const Metrics = () => {
         self.indexOf(value) === index
     )
   }
-  const [selectedRoster, setSelectedRoster] = useState<string>('WI22')
+  const [selectedRoster, setSelectedRoster] = useState<string>('WI23')
   const chosenSemesterStudents = allStudents.filter(
     (e) => e.semester === selectedRoster
   )
@@ -264,7 +264,7 @@ export const Metrics = () => {
         >
           <MenuItem value="SU22">Summer 2022</MenuItem>
           <MenuItem value="FA22">Fall 2022</MenuItem>
-          <MenuItem value="WI22">Winter 2022</MenuItem>
+          <MenuItem value="WI23">Winter 2023</MenuItem>
           <MenuItem value="SP23">Spring 2023</MenuItem>
         </DropdownSelect>
       </Box>

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -152,7 +152,7 @@ export const Metrics = () => {
         self.indexOf(value) === index
     )
   }
-  const [selectedRoster, setSelectedRoster] = useState<string>('FA22')
+  const [selectedRoster, setSelectedRoster] = useState<string>('WI22')
   const chosenSemesterStudents = allStudents.filter(
     (e) => e.semester === selectedRoster
   )


### PR DESCRIPTION
### Summary <!-- Required -->

Change the roster for classes that the survey uses to use Winter 2023 instead of Fall 2022. When students submit surveys now they will be added to the Winter 2023 iteration of the course.

- [x] change roster to WI23 (both where the surveys go in the backend and default in dashboard)
- [x] changed already present option Winter 2022 to Winter 2023

### Test Plan <!-- Required -->

I ran the `npm run populate` script and saw if everything was Winter 2023 (correct roster, so not all courses would be added, and dashboard would show the same, and the URL will show the same).
