### PR TITLE
Changing Default Roster to Prepare for Spring 2023 Semester

### DIFF
--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -82,7 +82,7 @@ export const addStudentSurveyResponse = async (
   year: string,
   courseCatalogNames: string[]
 ) => {
-  const roster = 'WI23' // Winter 2023
+  const roster = 'SP23' // Spring 2023
 
   // 0. Check if email is valid cornell.edu email.
   const emailRegex = /^\w+@cornell.edu$/

--- a/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
+++ b/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
@@ -179,6 +179,9 @@ export const AccountMenu = ({
         <MenuItem onClick={() => setSelectedRoster('SP23')}>
           Spring 2023
         </MenuItem>
+        <MenuItem onClick={() => setSelectedRoster('SU23')}>
+          Summer 2023
+        </MenuItem>
       </Menu>
     </Box>
   )

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -161,7 +161,7 @@ export const Dashboard = () => {
     })
   }
 
-  const [selectedRoster, setSelectedRoster] = useState<string>('WI23')
+  const [selectedRoster, setSelectedRoster] = useState<string>('SP23')
 
   const [query, setQuery] = useState('')
 

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -152,7 +152,7 @@ export const Metrics = () => {
         self.indexOf(value) === index
     )
   }
-  const [selectedRoster, setSelectedRoster] = useState<string>('WI23')
+  const [selectedRoster, setSelectedRoster] = useState<string>('SP23')
   const chosenSemesterStudents = allStudents.filter(
     (e) => e.semester === selectedRoster
   )

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -266,6 +266,7 @@ export const Metrics = () => {
           <MenuItem value="FA22">Fall 2022</MenuItem>
           <MenuItem value="WI23">Winter 2023</MenuItem>
           <MenuItem value="SP23">Spring 2023</MenuItem>
+          <MenuItem value="SU23">Summer 2023</MenuItem>
         </DropdownSelect>
       </Box>
       <MetricsTable


### PR DESCRIPTION
# Summary <!-- Required -->

Changes the default roster that the survey and dashboard default to. 


- [x] Changes Roster to SP23 - backend for surveys & default for the frontend dashboard. 
- [x] Added options for Summer 2023 (non-functional) - for the future.

# Test Plan <!-- Required -->

Running `npm run populate` correctly displays submitted surveys only on the Spring Tab. Firebase also correctly prefixes students `courseId` with `SP23`.