### PR TITLE
Oldest request first

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -15,7 +15,11 @@ import { Course } from '@core/Types'
 import { useHistory } from 'react-router-dom'
 import { AccountMenu } from 'Dashboard/Components/AccountMenu'
 import ClearIcon from '@mui/icons-material/Clear'
-type SortOrder = 'newest-requests-first' | 'classes-a-z' | 'classes-z-a'
+type SortOrder =
+  | 'newest-requests-first'
+  | 'oldest-requests-first'
+  | 'classes-a-z'
+  | 'classes-z-a'
 
 type FilterOption =
   | 'no-filter'
@@ -40,6 +44,7 @@ const filterOptionDisplay = [
 ]
 const sortOrderDisplay = [
   ['newest-requests-first', 'Newest Requests First'],
+  ['oldest-requests-first', 'Oldest Requests First'],
   ['classes-a-z', 'Classes A-Z'],
   ['classes-z-a', 'Classes Z-A'],
 ]

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -128,6 +128,14 @@ export const Dashboard = () => {
           (a, b) =>
             b.latestSubmissionTime.valueOf() - a.latestSubmissionTime.valueOf()
         )
+      case 'oldest-requests-first':
+        return [...courseInfo]
+          .sort(
+            (a, b) =>
+              b.latestSubmissionTime.valueOf() -
+              a.latestSubmissionTime.valueOf()
+          )
+          .reverse()
       case 'classes-a-z':
         return [...courseInfo].sort((a, b) => {
           return a.names[0].localeCompare(b.names[0], undefined, {

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -132,10 +132,9 @@ export const Dashboard = () => {
         return [...courseInfo]
           .sort(
             (a, b) =>
-              b.latestSubmissionTime.valueOf() -
-              a.latestSubmissionTime.valueOf()
+              a.latestSubmissionTime.valueOf() -
+              b.latestSubmissionTime.valueOf()
           )
-          .reverse()
       case 'classes-a-z':
         return [...courseInfo].sort((a, b) => {
           return a.names[0].localeCompare(b.names[0], undefined, {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements a sorting method to sort the oldest classes first.

- [x] implemented X
- [ ] fixed Y

### Test Plan <!-- Required -->

Here is "newest requests first"
<img width="1512" alt="Screen Shot 2023-02-08 at 6 38 39 PM" src="https://user-images.githubusercontent.com/52147838/217676728-bc4becec-4aff-46b5-a507-91a359e11868.png">

Here is "oldest requests first." As you can see, it looks rather alike to backwards "newest requests first," because it is.
<img width="1512" alt="Screen Shot 2023-02-08 at 6 38 50 PM" src="https://user-images.githubusercontent.com/52147838/217677196-d399d0d5-4d67-4095-b5ed-ee57418bd313.png">

When you refresh or go somewhere else and come back, the sorting still stays in the state you left it, so that feature still works.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

<!-- Keep items that apply: -->
