### PR TITLE
Fixed requires with Object.entries instead

### DIFF
--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -10,7 +10,7 @@ import { MetricsTable } from './MetricsTable'
 import { DropdownSelect } from '@core/Components'
 import { DASHBOARD_PATH } from '@core/Constants'
 import { Link } from 'react-router-dom'
-
+import survey from '@core/Questions/Questions.json'
 export const Metrics = () => {
   const { courses } = useCourseValue()
   const { students } = useStudentValue()
@@ -28,9 +28,7 @@ export const Metrics = () => {
     return date >= firstDayOfWeek && date <= lastDayOfWeek
   }
 
-  const collegeAbbreviations = require('@core/Questions/Questions.json')[0][
-    'answers'
-  ]
+  const collegeAbbreviations = new Map(Object.entries(survey[0]['answers']))
   const numStudentsInWeek = students.map((student) =>
     student.groups.filter((membership) =>
       isDateInThisWeek(membership.submissionTime)
@@ -174,7 +172,7 @@ export const Metrics = () => {
     })
     const groups = getUniqueValues(createdGroups.map((s) => s.groupNumber))
     return {
-      rowName: collegeAbbreviations[college],
+      rowName: collegeAbbreviations.get(college),
       students: uniqueStudents.length,
       requests: specificCollegeStudents.length,
       matches: matches,

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-
 import axios from 'axios'
 import { Question } from '@core/Types'
 import { API_ROOT, STUDENT_API } from '@core/Constants'
@@ -14,6 +13,7 @@ import { StepRadio } from 'Survey/Components/StepRadio'
 import { StepFinal } from 'Survey/Components/StepFinal'
 import { SurveyData } from 'Survey/Components/FuncsAndConsts/SurveyFunctions'
 import { SurveySubmissionResponse } from 'Survey/Types'
+import survey from '@core/Questions/Questions.json'
 
 export const Survey = () => {
   const [currStep, setCurrStep] = useState(1)
@@ -28,8 +28,18 @@ export const Survey = () => {
   const [isSubmittingSurvey, setIsSubmittingSurvey] = useState(false)
 
   // If there are custom questions the below will be a network call perhaps
-  const questions: Question[] = require('@core/Questions/Questions.json')
-  // import questions from '@core/Questions/Questions.json'
+  const questions: Question[] = survey.map((question) => {
+    var obj: { [key: string]: string } = {}
+    Object.entries(question.answers).forEach((answer) => {
+      obj[answer[0]] = answer[1]
+    })
+    return {
+      question: question.question,
+      questionId: question.questionId,
+      answers: obj,
+    }
+  })
+
   const numSpecialQuestions = 1 // Course list
   const totalSteps = questions.length + numSpecialQuestions + 1
 

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -31,7 +31,9 @@ export const Survey = () => {
   const questions: Question[] = survey.map((question) => {
     var obj: { [key: string]: string } = {}
     Object.entries(question.answers).forEach((answer) => {
-      obj[answer[0]] = answer[1]
+      if (answer[0] && answer[1]) {
+        obj[answer[0]] = answer[1]
+      }
     })
     return {
       question: question.question,


### PR DESCRIPTION
### Summary <!-- Required -->

Fixed bug with survey because requires does not work with vite. Used object.entries instead to interpret the json values so that it could be displayed on the frontend. This affected both the survey and metrics page.

### Test Plan <!-- Required -->

Tested walking through survey and checking metrics page when populated with classes to see if the right college names showed up.
<img width="1208" alt="Screenshot 2023-02-12 at 5 48 33 PM" src="https://user-images.githubusercontent.com/94809605/218341986-e100d123-ab02-473e-95d6-318059c31cf3.png">
<img width="1046" alt="Screenshot 2023-02-12 at 5 48 02 PM" src="https://user-images.githubusercontent.com/94809605/218342007-787c427f-594e-4e8e-8bc3-04d5bdf69354.png">

### Notes <!-- Optional -->




### Breaking Changes <!-- Optional -->

