### PR TITLE
Changed default to be none when picking email templates

### DIFF
--- a/frontend/src/modules/Core/Types/FormFieldProps.ts
+++ b/frontend/src/modules/Core/Types/FormFieldProps.ts
@@ -57,7 +57,7 @@ export interface GoToButtonProps extends Common {
 }
 
 export interface RadioButtonProps extends Common {
-  currentAnswer: string
+  currentAnswer: string | undefined
   onClick: (e: React.ChangeEvent<HTMLInputElement>) => void
   value: string
   label: string

--- a/frontend/src/modules/Core/Types/FormFieldProps.ts
+++ b/frontend/src/modules/Core/Types/FormFieldProps.ts
@@ -57,7 +57,7 @@ export interface GoToButtonProps extends Common {
 }
 
 export interface RadioButtonProps extends Common {
-  currentAnswer: string | undefined
+  currentAnswer: string
   onClick: (e: React.ChangeEvent<HTMLInputElement>) => void
   value: string
   label: string

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -40,9 +40,9 @@ export const EmailModal = ({
   )
 
   // template editor logic
-  const [selectedTemplate, setSelectedTemplate] = useState<EmailTemplate>(
-    filteredTemplates[0]
-  )
+  const [selectedTemplate, setSelectedTemplate] = useState<
+    EmailTemplate | undefined
+  >(undefined)
 
   // Special value substitution in template HTML
   const replaceMap = {
@@ -301,7 +301,7 @@ export const EmailModal = ({
           onClick={() => {
             setStep(1)
           }}
-          disabled={!selectedTemplate}
+          disabled={!selectedTemplate || selectedTemplate === undefined}
           sx={{ position: 'absolute', bottom: '24px', right: '24px' }}
         >
           Next
@@ -409,7 +409,7 @@ export const EmailModal = ({
         </Box>
       </ZingModal.Title>
       <ZingModal.Body>
-        {selectedTemplate ? (
+        {filteredTemplates.length !== 0 ? (
           <Box sx={{ padding: '1rem 3.5rem 0 3.5rem' }}>
             {step <= 1 && <SelectTemplates />}
             {step === 2 && <StepFailure />}

--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -301,7 +301,7 @@ export const EmailModal = ({
           onClick={() => {
             setStep(1)
           }}
-          disabled={!selectedTemplate || selectedTemplate === undefined}
+          disabled={!selectedTemplate}
           sx={{ position: 'absolute', bottom: '24px', right: '24px' }}
         >
           Next

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -34,7 +34,7 @@ export const EmailTemplateButtons = ({
         labels={templateNames}
         values={templateIds}
         onClick={handleChange}
-        currentAnswer={selectedTemplate.id}
+        currentAnswer={selectedTemplate ? selectedTemplate.id : undefined}
       />
     </Box>
   )

--- a/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailTemplateButtons.tsx
@@ -34,7 +34,7 @@ export const EmailTemplateButtons = ({
         labels={templateNames}
         values={templateIds}
         onClick={handleChange}
-        currentAnswer={selectedTemplate ? selectedTemplate.id : undefined}
+        currentAnswer={selectedTemplate ? selectedTemplate.id : ''}
       />
     </Box>
   )


### PR DESCRIPTION
- added undefined as value for selected template

### Summary <!-- Required -->

- The next button is disabled until a template is selected. If the back button is clicked, the previously chosen template stays selected. 

### Test Plan <!-- Required -->

I went back and forth on the pages and tested the email template modal for various different groups.

https://user-images.githubusercontent.com/94809605/219997663-b4c4e4d3-5e07-4132-a685-40bdc50b1682.mov


### Notes <!-- Optional -->


### Breaking Changes <!-- Optional -->

