### PR TITLE
[FIXED] Standardize Zing-LSC Theme

### DIFF
--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -304,6 +304,25 @@ theme = createTheme(theme, {
         },
       },
     },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          transition: 'box-shadow 0.1s',
+        },
+        elevation1: {
+          boxShadow: '0px 2px 5px rgba(205, 156, 242, 0.2)',
+        },
+        elevation2: {
+          boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.07)',
+        },
+        elevation3: {
+          boxShadow: '4px 4px 8px rgba(0, 0, 0, 0.3)',
+        },
+        elevation4: {
+          boxShadow: '4px 4px 10px rgba(0, 0, 0, 0.3)',
+        },
+      },
+    },
   },
 })
 

--- a/frontend/src/modules/Core/Constants/Theme.ts
+++ b/frontend/src/modules/Core/Constants/Theme.ts
@@ -294,6 +294,16 @@ theme = createTheme(theme, {
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: theme.palette.essentials.main,
+          color: 'white',
+          fontWeight: 600,
+          borderRadius: '10px',
+        },
+      },
+    },
   },
 })
 

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -4,7 +4,14 @@ import { GroupGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrop } from 'react-dnd'
 import { STUDENT_TYPE, DnDStudentTransferType } from 'EditZing/Types/Student'
 import { StyledGroupText } from 'EditZing/Styles/StudentAndGroup.style'
-import { Box, Tooltip, Checkbox, IconButton, Button } from '@mui/material'
+import {
+  Box,
+  Tooltip,
+  Checkbox,
+  IconButton,
+  Button,
+  Paper,
+} from '@mui/material'
 import CircleIcon from '@mui/icons-material/Circle'
 import { Delete, Undo } from '@mui/icons-material'
 import axios from 'axios'
@@ -92,127 +99,121 @@ const GroupCard = ({
   }
 
   return (
-    <Box>
+    <Paper
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
+      ref={drop}
+      sx={{
+        width: '380px',
+        height: '350px',
+        padding: '2rem',
+        border: 0.5,
+        borderColor: selected || isHovering ? 'purple.50' : 'purple.16',
+        borderRadius: '20px',
+        margin: '0.25rem',
+        backgroundColor: selected ? 'rgba(129, 94, 212, 0.15);' : 'white',
+        opacity: isOver ? '0.6' : '1',
+      }}
+      elevation={isHovering && !selected ? 4 : 2}
+    >
+      <Box display="flex" alignItems="center" sx={{ mb: 2, height: '42px' }}>
+        <Tooltip
+          title={
+            'Created on ' +
+            (createTime.getMonth() + 1) +
+            '/' +
+            createTime.getDate()
+          }
+        >
+          <StyledGroupText>{`Group ${groupNumber}`}</StyledGroupText>
+        </Tooltip>
+        {tooltipTimestamps.map((timestamp, index) => {
+          const month = timestamp.timestamp.getMonth() + 1
+          const day = timestamp.timestamp.getDate()
+          return (
+            <Tooltip
+              key={index}
+              title={`${timestamp.name + ': ' + month}/${day}`}
+              placement="bottom-start"
+            >
+              <CircleIcon sx={{ fontSize: 10 }} color="primary" />
+            </Tooltip>
+          )
+        })}
+        <Box flexGrow={2} />
+        <IconButton
+          color="secondary"
+          sx={{
+            display:
+              studentList.length === 0 && isHovering && !recentlyRemoved
+                ? 'flex'
+                : 'none',
+            backgroundColor: 'transparent',
+            border: 'none',
+          }}
+          onClick={() => {
+            removeGroup(courseId, groupNumber)
+          }}
+        >
+          <Delete sx={{ color: 'purple' }}></Delete>
+        </IconButton>
+        <IconButton
+          color="secondary"
+          sx={{
+            display: recentlyRemoved ? 'flex' : 'none',
+            backgroundColor: 'transparent',
+            border: 'none',
+          }}
+          onClick={() => {
+            undoRemoveGroup(courseId, groupNumber)
+          }}
+        >
+          <Undo sx={{ color: 'purple' }}></Undo>
+        </IconButton>
+
+        <Checkbox
+          color="secondary"
+          checked={selected}
+          onChange={handleChecked}
+          sx={{
+            display:
+              selected || (studentList.length !== 0 && isHovering)
+                ? 'flex'
+                : 'none',
+          }}
+        />
+      </Box>
+
       <Box
-        onMouseOver={handleMouseOver}
-        onMouseOut={handleMouseOut}
-        ref={drop}
         sx={{
-          width: '380px',
-          height: '350px',
-          padding: '2rem',
-          border: 0.5,
-          borderColor: selected || isHovering ? 'purple.50' : 'purple.16',
-          boxShadow:
-            !selected && isHovering
-              ? '4px 4px 10px rgba(0, 0, 0, 0.3)'
-              : '0px 4px 10px rgba(0, 0, 0, 0.07)',
-          borderRadius: '20px',
-          margin: '0.25rem',
-          backgroundColor: selected ? 'rgba(129, 94, 212, 0.15);' : 'white',
-          opacity: isOver ? '0.6' : '1',
-          transition: 'box-shadow 0.1s',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(112px, max-content))',
+          gap: '16px',
         }}
       >
-        <Box display="flex" alignItems="center" sx={{ mb: 2, height: '42px' }}>
-          <Tooltip
-            title={
-              'Created on ' +
-              (createTime.getMonth() + 1) +
-              '/' +
-              createTime.getDate()
-            }
-          >
-            <StyledGroupText>{`Group ${groupNumber}`}</StyledGroupText>
-          </Tooltip>
-          {tooltipTimestamps.map((timestamp, index) => {
-            const month = timestamp.timestamp.getMonth() + 1
-            const day = timestamp.timestamp.getDate()
-            return (
-              <Tooltip
-                key={index}
-                title={`${timestamp.name + ': ' + month}/${day}`}
-                placement="bottom-start"
-              >
-                <CircleIcon sx={{ fontSize: 10 }} color="primary" />
-              </Tooltip>
-            )
-          })}
-          <Box flexGrow={2} />
-          <IconButton
-            color="secondary"
-            sx={{
-              display:
-                studentList.length === 0 && isHovering && !recentlyRemoved
-                  ? 'flex'
-                  : 'none',
-              backgroundColor: 'transparent',
-              border: 'none',
-            }}
-            onClick={() => {
-              removeGroup(courseId, groupNumber)
-            }}
-          >
-            <Delete sx={{ color: 'purple' }}></Delete>
-          </IconButton>
-          <IconButton
-            color="secondary"
-            sx={{
-              display: recentlyRemoved ? 'flex' : 'none',
-              backgroundColor: 'transparent',
-              border: 'none',
-            }}
-            onClick={() => {
-              undoRemoveGroup(courseId, groupNumber)
-            }}
-          >
-            <Undo sx={{ color: 'purple' }}></Undo>
-          </IconButton>
-
-          <Checkbox
-            color="secondary"
-            checked={selected}
-            onChange={handleChecked}
-            sx={{
-              display:
-                selected || (studentList.length !== 0 && isHovering)
-                  ? 'flex'
-                  : 'none',
-            }}
+        {studentList.map((student, index) => (
+          <StudentCard
+            key={index}
+            courseId={courseId}
+            groupNumber={groupNumber}
+            student={student}
+            templateMap={templateMap}
+            selected={selectedStudents.includes(student.email)}
+            handleAddStudent={handleAddStudent}
+            updateNotes={updateNotes}
           />
-        </Box>
-
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(112px, max-content))',
-            gap: '16px',
-          }}
-        >
-          {studentList.map((student, index) => (
-            <StudentCard
-              key={index}
-              courseId={courseId}
-              groupNumber={groupNumber}
-              student={student}
-              templateMap={templateMap}
-              selected={selectedStudents.includes(student.email)}
-              handleAddStudent={handleAddStudent}
-              updateNotes={updateNotes}
-            />
-          ))}
-        </Box>
-        <Button
-          onClick={() => fullyRemoveGroup(courseId, groupNumber)}
-          sx={{
-            display: recentlyRemoved ? 'fixed' : 'none',
-            top: '175px',
-          }}
-        >
-          Confirm Delete
-        </Button>
+        ))}
       </Box>
-    </Box>
+      <Button
+        onClick={() => fullyRemoveGroup(courseId, groupNumber)}
+        sx={{
+          display: recentlyRemoved ? 'fixed' : 'none',
+          top: '175px',
+        }}
+      >
+        Confirm Delete
+      </Button>
+    </Paper>
   )
 }
 

--- a/frontend/src/modules/EditZing/Components/GroupCard.tsx
+++ b/frontend/src/modules/EditZing/Components/GroupCard.tsx
@@ -133,16 +133,6 @@ const GroupCard = ({
                 key={index}
                 title={`${timestamp.name + ': ' + month}/${day}`}
                 placement="bottom-start"
-                componentsProps={{
-                  tooltip: {
-                    sx: {
-                      bgcolor: 'essentials.main',
-                      color: 'white',
-                      fontWeight: 600,
-                      borderRadius: '10px',
-                    },
-                  },
-                }}
               >
                 <CircleIcon sx={{ fontSize: 10 }} color="primary" />
               </Tooltip>

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -191,16 +191,6 @@ const StudentCard = ({
                     key={index}
                     title={`${timestamp.name + ': ' + month}/${day}`}
                     placement="bottom-start"
-                    componentsProps={{
-                      tooltip: {
-                        sx: {
-                          bgcolor: 'essentials.main',
-                          color: 'white',
-                          fontWeight: 600,
-                          borderRadius: '10px',
-                        },
-                      },
-                    }}
                   >
                     <CircleIcon sx={{ fontSize: 10 }} color="primary" />
                   </Tooltip>

--- a/frontend/src/modules/EditZing/Components/StudentCard.tsx
+++ b/frontend/src/modules/EditZing/Components/StudentCard.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import Paper from '@mui/material/Paper'
 import { STUDENT_TYPE } from 'EditZing/Types/Student'
 import { StudentGridProps } from 'EditZing/Types/ComponentProps'
 import { useDrag } from 'react-dnd'
@@ -11,6 +10,7 @@ import {
   Snackbar,
   IconButton,
   SvgIcon,
+  Paper,
 } from '@mui/material'
 import NotesModal from './NotesModal'
 import { ReactComponent as FilledEditIcon } from '@assets/img/FilledEditIcon.svg'
@@ -141,14 +141,10 @@ const StudentCard = ({
             fontFamily: 'Montserrat',
             fontWeight: '700',
             fontSize: '14',
-            boxShadow:
-              isHovering && !selected
-                ? '4px 4px 8px rgba(0, 0, 0, 0.3)'
-                : '0px 2px 5px rgba(205, 156, 242, 0.2)',
             borderRadius: '10px',
             width: '100%',
-            transition: 'box-shadow 0.1s',
           }}
+          elevation={isHovering && !selected ? 3 : 1}
         >
           <Box
             sx={{


### PR DESCRIPTION
### 
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request standardizes parts of Zing-LSC's theme to make styling easier. It is a redo of #137 since there were unsolvable merge issues.

- [x] Standardize tooltip appearance
- [x] Standardize hover shadows for student and group cards

### Test Plan <!-- Required -->

Testing was performed by running the application locally and verifying that there were no visual irregularities due to standardizing the styling.

Standardized Tooltips:
<img width="403" alt="Screenshot 2022-12-14 at 2 03 34 PM" src="https://user-images.githubusercontent.com/45516888/207689355-ddb2959a-5cf7-48e9-a7f3-be852a50d1a8.png">