### PR TITLE
Fixed matchable filter

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -104,7 +104,7 @@ export const Dashboard = () => {
       case 'matchable':
         return [...courseInfo].filter(
           (course, _) =>
-            (course.lastGroupNumber > 0 && course.unmatched.length > 0) ||
+            (course.lastGroupNumber > 0 && course.unmatched.length > 1) ||
             (course.lastGroupNumber === 0 && course.unmatched.length > 1)
         )
       case 'can-add-to-existing-group':
@@ -129,12 +129,10 @@ export const Dashboard = () => {
             b.latestSubmissionTime.valueOf() - a.latestSubmissionTime.valueOf()
         )
       case 'oldest-requests-first':
-        return [...courseInfo]
-          .sort(
-            (a, b) =>
-              a.latestSubmissionTime.valueOf() -
-              b.latestSubmissionTime.valueOf()
-          )
+        return [...courseInfo].sort(
+          (a, b) =>
+            a.latestSubmissionTime.valueOf() - b.latestSubmissionTime.valueOf()
+        )
       case 'classes-a-z':
         return [...courseInfo].sort((a, b) => {
           return a.names[0].localeCompare(b.names[0], undefined, {


### PR DESCRIPTION
### Summary <!-- Required -->

We have a bug where the "matchable" filter contains classes where there's only one unmatched student with nonzero groups, but this case should instead be contained only within the "can add to already existing group" filter. 

For example, in the below filter instance, ILRST 2100 should not appear in matchable.
![Untitled](https://user-images.githubusercontent.com/100158738/222844378-4c002d66-1a8f-4980-b9d6-98fd73a8bbc7.png)

To fix this, we just ensure that the "matchable" criteria doesn't include the case where there's exactly one unmatched student and multiple available groups.

### Test Plan <!-- Required -->

CS 2110 has nonzero groups and one unmatched student, but it no longer appears in "matchable" and instead appears only in "can add to already existing group" filter.

https://user-images.githubusercontent.com/100158738/222845295-70ee0896-d36f-402c-a584-0c717627382d.mov

