### PR TITLE
Settings Patch v0.1 

### DIFF
--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -16,7 +16,7 @@ export const setCurrentSemester = async (sem: String) => {
 
 export const getAllSemesters = async () => {
   const semData = (await semesterRef.get()).data() as Semester
-  return [semData.currentSemester, ...semData.allSemesters]
+  return semData.allSemesters
 }
 
 export const getSurveyStatus = async () => {
@@ -25,7 +25,7 @@ export const getSurveyStatus = async () => {
 }
 
 export const setSurveyStatus = async (status: Boolean) => {
-  return semesterRef.update({ surveyOpen: status })
+  return semesterRef.set({ surveyOpen: status })
 }
 
 async function getCourseInfo(courseId: string) {

--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -11,7 +11,12 @@ export const getCurrentSemester = async (): Promise<String> => {
 }
 
 export const setCurrentSemester = async (sem: String) => {
-  return semesterRef.set({ currentSemester: sem, surveyOpen: false })
+  const semData = (await semesterRef.get()).data() as Semester
+  return semesterRef.set({
+    ...semData,
+    currentSemester: sem,
+    surveyOpen: false,
+  })
 }
 
 export const getAllSemesters = async () => {
@@ -25,7 +30,8 @@ export const getSurveyStatus = async () => {
 }
 
 export const setSurveyStatus = async (status: Boolean) => {
-  return semesterRef.set({ surveyOpen: status })
+  const semData = (await semesterRef.get()).data() as Semester
+  return semesterRef.set({ ...semData, surveyOpen: status })
 }
 
 async function getCourseInfo(courseId: string) {

--- a/backend/functions/src/course/functions.ts
+++ b/backend/functions/src/course/functions.ts
@@ -15,7 +15,6 @@ export const setCurrentSemester = async (sem: String) => {
   return semesterRef.set({
     ...semData,
     currentSemester: sem,
-    surveyOpen: false,
   })
 }
 

--- a/backend/functions/src/global/functions.ts
+++ b/backend/functions/src/global/functions.ts
@@ -1,0 +1,27 @@
+import { db } from '../config'
+import { Semester } from '../types'
+
+const semesterRef = db.collection('utils').doc('semester')
+
+export const getCurrentSemester = async (): Promise<String> => {
+  const semData = (await semesterRef.get()).data() as Semester
+  return semData.currentSemester
+}
+
+export const setCurrentSemester = async (sem: String) => {
+  return semesterRef.set({ currentSemester: sem, surveyOpen: false })
+}
+
+export const getAllSemesters = async () => {
+  const semData = (await semesterRef.get()).data() as Semester
+  return semData.allSemesters
+}
+
+export const getSurveyStatus = async () => {
+  const semData = (await semesterRef.get()).data() as Semester
+  return semData.surveyOpen
+}
+
+export const setSurveyStatus = async (status: Boolean) => {
+  return semesterRef.set({ surveyOpen: status })
+}

--- a/backend/functions/src/global/functions.ts
+++ b/backend/functions/src/global/functions.ts
@@ -1,15 +1,22 @@
 import { db } from '../config'
 import { Semester } from '../types'
+import admin from 'firebase-admin'
 
 const semesterRef = db.collection('utils').doc('semester')
 
-export const getCurrentSemester = async (): Promise<String> => {
+export const getCurrentSemester = async (): Promise<string> => {
   const semData = (await semesterRef.get()).data() as Semester
   return semData.currentSemester
 }
 
-export const setCurrentSemester = async (sem: String) => {
+export const setCurrentSemester = async (sem: string) => {
   return semesterRef.set({ currentSemester: sem, surveyOpen: false })
+}
+
+export const addNewSemester = async (sem: string) => {
+  return semesterRef.update({
+    allSemesters: admin.firestore.FieldValue.arrayUnion(sem),
+  })
 }
 
 export const getAllSemesters = async () => {
@@ -22,6 +29,6 @@ export const getSurveyStatus = async () => {
   return semData.surveyOpen
 }
 
-export const setSurveyStatus = async (status: Boolean) => {
+export const setSurveyStatus = async (status: boolean) => {
   return semesterRef.set({ surveyOpen: status })
 }

--- a/backend/functions/src/global/routes.ts
+++ b/backend/functions/src/global/routes.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express'
+import { config } from 'dotenv'
+import { logger } from 'firebase-functions'
+import {
+  getCurrentSemester,
+  getAllSemesters,
+  getSurveyStatus,
+} from './functions'
+
+const router = Router()
+config()
+
+router.get('/semester/current', (_, res) => {
+  getCurrentSemester()
+    .then((data) => res.status(200).send(data))
+    .catch((err) => {
+      const err_msg = `Unexpected error getting semester: ${err.msg}`
+      logger.error(err_msg)
+      res.status(500).send({ message: err_msg })
+    })
+})
+
+router.get('/semester/all', (_, res) => {
+  getAllSemesters()
+    .then((data) => res.status(200).send(data))
+    .catch((err) => {
+      const err_msg = `Unexpected error getting all semesters: ${err.message}`
+      logger.error(err_msg)
+      res.status(500).send({ message: err_msg })
+    })
+})
+
+router.get('/semester/survey', (_, res) => {
+  getSurveyStatus()
+    .then((data) => res.status(200).send(data))
+    .catch((err) => {
+      logger.error(`Unexpected error retrieving survey opening: ${err.message}`)
+      res.status(500).send({ message: err.message })
+    })
+})
+
+export default router

--- a/backend/functions/src/global/routes.ts
+++ b/backend/functions/src/global/routes.ts
@@ -5,6 +5,7 @@ import {
   getCurrentSemester,
   getAllSemesters,
   getSurveyStatus,
+  addNewSemester,
 } from './functions'
 
 const router = Router()
@@ -15,6 +16,17 @@ router.get('/semester/current', (_, res) => {
     .then((data) => res.status(200).send(data))
     .catch((err) => {
       const err_msg = `Unexpected error getting semester: ${err.msg}`
+      logger.error(err_msg)
+      res.status(500).send({ message: err_msg })
+    })
+})
+
+router.post('/semester', (req, res) => {
+  const { semester } = req.body
+  addNewSemester(semester)
+    .then((data) => res.status(200).send(data))
+    .catch((err) => {
+      const err_msg = `Unexpected error adding semester: ${err.msg}`
       logger.error(err_msg)
       res.status(500).send({ message: err_msg })
     })

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -18,6 +18,9 @@ import matchingRouter from './matching/routes'
 import courseRouter from './course/routes'
 import emailRouter from './emailing/routes'
 
+// global routers - no auth
+import globalRouter from './global/routes'
+
 // // Start writing Firebase Functions
 // // https://firebase.google.com/docs/functions/typescript
 //
@@ -34,6 +37,9 @@ const app = express()
 app.use(express.json())
 app.use(cors())
 app.use(logReqBody)
+
+// global routers - no auth
+app.use('/global', globalRouter)
 
 // auth middleware before router
 app.use(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,24 @@ const App = () => {
     </Button>
   )
 
+  const semValueMap = new Map([
+    ['WI', 0],
+    ['SP', 1],
+    ['SU', 2],
+    ['FA', 3],
+  ])
+
+  const sortSemesters = (a: string, b: string) => {
+    const aSemPrefix = a.substring(0, 2)
+    const bSemPrefix = b.substring(0, 2)
+    const aSemYear = Number(a.substring(2))
+    const bSemYear = Number(b.substring(2))
+    return (
+      aSemYear - bSemYear ||
+      semValueMap.get(aSemPrefix)! - semValueMap.get(bSemPrefix)!
+    )
+  }
+
   useEffect(() => {
     onAuthStateChanged(auth, (user) => {
       setCurrentUser(user)
@@ -126,12 +144,17 @@ const App = () => {
   // Application-wide courses are only loaded when user is authorized
   const [hasLoadedCourses, setHasLoadedCourses] = useState(false)
   const [courses, setCourses] = useState<Course[]>([])
+  const [semesters, setSemesters] = useState<string[]>([])
 
   const loadCourses = () => {
     axios.get(`${API_ROOT}${COURSE_API}`).then(
       (res) => {
         setCourses(res.data.map(responseCourseToCourse))
-        setHasLoadedCourses(true)
+        // TODO: MOVE THIS TO ITS OWN CONTEXT
+        axios.get(`${API_ROOT}${COURSE_API}/semester/all`).then((res) => {
+          setHasLoadedCourses(true)
+          setSemesters(res.data.sort(sortSemesters))
+        })
       },
       (error) => {
         console.log(error)
@@ -617,6 +640,7 @@ const App = () => {
             <CourseProvider
               value={{
                 hasLoadedCourses,
+                semesters,
                 courses,
                 moveStudent,
                 matchStudents,

--- a/frontend/src/context/CourseContext.tsx
+++ b/frontend/src/context/CourseContext.tsx
@@ -4,6 +4,7 @@ import { Course } from '@core/Types'
 interface CourseContextType {
   hasLoadedCourses: boolean
   courses: Course[]
+  semesters: string[]
   moveStudent: (
     studentEmail: string,
     courseId: string,
@@ -23,6 +24,7 @@ interface CourseContextType {
 const CourseContext = React.createContext<CourseContextType>({
   hasLoadedCourses: false,
   courses: [],
+  semesters: [],
   moveStudent: () => {},
   matchStudents: async () => {},
   addGroupEmailTimestamps: () => {},

--- a/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
+++ b/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
@@ -137,10 +137,14 @@ export const AccountMenu = ({
         >
           <MenuItem>Export CSV (Students)</MenuItem>
         </CSVLink>
-        <MenuItem onClick={handleRosterClick}>
+        <MenuItem component={Link} to="/settings">
+          <ChevronLeftIcon sx={{ color: 'essentials.75', ml: -1 }} />
+          Settings
+        </MenuItem>
+        {/* <MenuItem onClick={handleRosterClick}>
           <ChevronLeftIcon sx={{ color: 'essentials.75', ml: -1 }} />
           Switch Semester
-        </MenuItem>
+        </MenuItem> */}
         {showMetricsLink && (
           <MenuItem component={Link} to="/metrics">
             Metrics

--- a/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
+++ b/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
@@ -138,13 +138,12 @@ export const AccountMenu = ({
           <MenuItem>Export CSV (Students)</MenuItem>
         </CSVLink>
         <MenuItem component={Link} to="/settings">
-          <ChevronLeftIcon sx={{ color: 'essentials.75', ml: -1 }} />
           Settings
         </MenuItem>
-        {/* <MenuItem onClick={handleRosterClick}>
+        <MenuItem onClick={handleRosterClick}>
           <ChevronLeftIcon sx={{ color: 'essentials.75', ml: -1 }} />
-          Switch Semester
-        </MenuItem> */}
+          Switch Viewing Semester
+        </MenuItem>
         {showMetricsLink && (
           <MenuItem component={Link} to="/metrics">
             Metrics

--- a/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
+++ b/frontend/src/modules/Dashboard/Components/AccountMenu.tsx
@@ -17,10 +17,9 @@ export const AccountMenu = ({
   setSelectedRoster,
   showMetricsLink,
   showDashboardLink,
-  showSettingsLink,
 }: AccountMenuProps) => {
   const { user } = useAuthValue()
-  const { courses } = useCourseValue()
+  const { courses, semesters } = useCourseValue()
   const { students } = useStudentValue()
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
@@ -179,19 +178,9 @@ export const AccountMenu = ({
           mt: -1.5,
         }}
       >
-        <MenuItem onClick={() => setSelectedRoster('SU22')}>
-          Summer 2022
-        </MenuItem>
-        <MenuItem onClick={() => setSelectedRoster('FA22')}>Fall 2022</MenuItem>
-        <MenuItem onClick={() => setSelectedRoster('WI23')}>
-          Winter 2023
-        </MenuItem>
-        <MenuItem onClick={() => setSelectedRoster('SP23')}>
-          Spring 2023
-        </MenuItem>
-        <MenuItem onClick={() => setSelectedRoster('SU23')}>
-          Summer 2023
-        </MenuItem>
+        {semesters.map((sem) => (
+          <MenuItem onClick={() => setSelectedRoster(sem)}>{sem}</MenuItem>
+        ))}
       </Menu>
     </Box>
   )

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import MenuItem from '@mui/material/MenuItem'
 import TextField from '@mui/material/TextField'
 import { ReactComponent as LogoImg } from '@assets/img/lscicon.svg'
@@ -15,6 +15,10 @@ import { Course } from '@core/Types'
 import { useHistory } from 'react-router-dom'
 import { AccountMenu } from 'Dashboard/Components/AccountMenu'
 import ClearIcon from '@mui/icons-material/Clear'
+
+import axios from 'axios'
+import { API_ROOT, COURSE_API } from '@core/Constants'
+
 type SortOrder =
   | 'newest-requests-first'
   | 'oldest-requests-first'
@@ -172,6 +176,15 @@ export const Dashboard = () => {
   }
 
   const [selectedRoster, setSelectedRoster] = useState<string>('SP23')
+
+  const initSelectedRoster = async () => {
+    await axios.get(`${API_ROOT}${COURSE_API}/semester/current`).then((req) => {
+      setSelectedRoster(req.data)
+    })
+  }
+  useEffect(() => {
+    initSelectedRoster()
+  }, [])
 
   const [query, setQuery] = useState('')
 

--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -207,7 +207,16 @@ export const Dashboard = () => {
       <StyledHeaderMenu>
         <LogoImg />
 
-        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexFlow: 'row wrap',
+            gap: '10px',
+            justifyContent: 'center',
+            alignContent: 'center',
+            alignItems: 'center',
+          }}
+        >
           <Box sx={{ display: 'flex', flexDirection: 'row' }}>
             <Box
               sx={{
@@ -293,14 +302,14 @@ export const Dashboard = () => {
               }}
             />
           </Box>
+          <AccountMenu
+            selectedRoster={selectedRoster}
+            setSelectedRoster={setSelectedRoster}
+            showMetricsLink={true}
+            showDashboardLink={false}
+            showSettingsLink={true}
+          />
         </Box>
-        <AccountMenu
-          selectedRoster={selectedRoster}
-          setSelectedRoster={setSelectedRoster}
-          showMetricsLink={true}
-          showDashboardLink={false}
-          showSettingsLink={true}
-        />
       </StyledHeaderMenu>
       <CourseGrid courses={filteredSortedCourses} />
     </StyledContainer>

--- a/frontend/src/modules/Dashboard/Styles/Dashboard.style.tsx
+++ b/frontend/src/modules/Dashboard/Styles/Dashboard.style.tsx
@@ -17,12 +17,12 @@ export const StyledContainer = styled.main`
 export const StyledHeaderMenu = styled.div`
   height: fit-content;
 
-  padding: 2.5rem;
-  padding-left: 10rem;
-  padding-right: 10rem;
+  padding: 3% 5%;
   display: flex;
+  flex-flow: row wrap;
+  gap: 10px;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-around;
 `
 
 export const StyledName = styled.div`

--- a/frontend/src/modules/Settings/Components/AdministratorsTable.tsx
+++ b/frontend/src/modules/Settings/Components/AdministratorsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, MouseEvent } from 'react'
+import { useState } from 'react'
 import { styled } from '@mui/material/styles'
 import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
@@ -10,11 +10,9 @@ import Paper from '@mui/material/Paper'
 import { DeleteOutline, Edit } from '@mui/icons-material'
 import { colors } from '@core'
 import { Box } from '@mui/material'
-import { API_ROOT } from '@core'
-import axios from 'axios'
 import { AllowedUsers, Admin } from './types'
 
-const StyledTableCell = styled(TableCell)(({ theme }) => ({
+const StyledTableCell = styled(TableCell)(() => ({
   [`&.${tableCellClasses.head}`]: {
     backgroundColor: colors.paleviolet,
     color: 'black',
@@ -56,6 +54,7 @@ export const AdministratorsTable = ({
     <Box
       sx={{
         m: 'auto',
+        mb: 6,
         pt: 1,
         display: 'flex',
         flexDirection: 'column',
@@ -102,14 +101,14 @@ export const AdministratorsTable = ({
                     sx={{
                       '&:hover': { scale: '1.2', cursor: 'pointer' },
                     }}
-                  ></DeleteOutline>
+                  />
                   <Edit
                     color="action"
                     onClick={editAdmin}
                     sx={{
                       '&:hover': { scale: '1.2', cursor: 'pointer' },
                     }}
-                  ></Edit>
+                  />
                 </StyledTableCell>
               </StyledTableRow>
             ))}

--- a/frontend/src/modules/Settings/Components/Settings.tsx
+++ b/frontend/src/modules/Settings/Components/Settings.tsx
@@ -256,7 +256,7 @@ export const Settings = () => {
                 Survey Status
               </Box>
               <Typography sx={{ width: '100%', maxWidth: '625px', mb: '8px' }}>
-                This settings turns off and on the survey that students can fill
+                This setting turns off and on the survey that students can fill
                 out to request new study partners.
               </Typography>
               <Box

--- a/frontend/src/modules/Settings/Components/Settings.tsx
+++ b/frontend/src/modules/Settings/Components/Settings.tsx
@@ -2,13 +2,15 @@ import { DropdownSelect } from '@core/index'
 import {
   Box,
   Button,
-  FormControl,
   IconButton,
   SelectChangeEvent,
   Switch,
   TextField,
+  Typography,
 } from '@mui/material'
 import MenuItem from '@mui/material/MenuItem'
+import AddIcon from '@mui/icons-material/Add'
+
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { DASHBOARD_PATH } from '@core/index'
@@ -110,19 +112,18 @@ export const Settings = () => {
   return (
     <Box
       sx={{
-        pl: '5rem',
-        pr: '5rem',
+        p: '0 5%',
         display: 'flex',
-        flexDirection: 'column',
+        flexFlow: 'column nowrap',
       }}
     >
       <Box
         sx={{
           width: '100%',
           height: 'fit-content',
-          padding: '2.5rem',
+          padding: '2.5rem 0',
           display: 'flex',
-          flexDirection: 'row',
+          flexFlow: 'row wrap',
           alignItems: 'center',
           justifyContent: 'space-between',
         }}
@@ -152,85 +153,132 @@ export const Settings = () => {
       </Box>
       <Box
         sx={{
-          pl: '5rem',
-          pr: '5rem',
           display: 'grid',
           alignItems: 'center',
         }}
       >
+        <Box sx={{ typography: 'h2', fontWeight: 'bold', p: '24px 0' }}>
+          Settings
+        </Box>
         <Box sx={{ display: 'flex' }}>
-          <Box sx={{ width: '70%', display: 'grid' }}>
-            <Box sx={{ typography: 'h4', fontWeight: 'bold' }}>Semester</Box>
-            <Box sx={{ typography: 'h5' }}>Current Semester:</Box>
-            <DropdownSelect
-              value={currRoster}
-              onChange={changeCurrRoster}
-              sx={{
-                alignContent: 'right',
-                right: '1px',
-              }}
-            >
-              {semesters.map((sem) => (
-                <MenuItem key={sem} value={sem}>
-                  {sem}
-                </MenuItem>
-              ))}
-            </DropdownSelect>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
+          <Box
+            sx={{
+              width: '100%',
+              display: 'flex',
+              flexFlow: 'row wrap',
+              justifyContent: 'left',
+              gap: '12px',
+              alignItems: 'center',
+              alignContent: 'center',
+            }}
+          >
+            <Box sx={{ width: '100%' }}>
+              <Box sx={{ typography: 'h6', fontWeight: '700', width: '100%' }}>
+                Current Semester
+              </Box>
+              <Typography sx={{ width: '100%', maxWidth: '625px' }}>
+                Changing the current semester here will change the semester that
+                the survey students submit to and the default viewing semester
+                for all users.
+              </Typography>
               <DropdownSelect
-                value={selectedSeason}
-                onChange={(event: SelectChangeEvent) => {
-                  setSelectedSeason(event.target.value)
+                value={currRoster}
+                onChange={changeCurrRoster}
+                sx={{
+                  width: '100%',
+                  maxWidth: '600px',
                 }}
               >
-                {semesterKeys.map((semester) => (
-                  <MenuItem key={semester} value={semester}>
-                    {semester}
+                {semesters.map((sem) => (
+                  <MenuItem key={sem} value={sem}>
+                    {sem}
                   </MenuItem>
                 ))}
               </DropdownSelect>
-              <TextField
-                label="Year"
-                variant="outlined"
-                type={'number'}
-                value={year}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setYear(event.target.value)
-                }}
-              />
-              <Button onClick={addSemester}>Add semester</Button>
             </Box>
-          </Box>
-          <Box
-            sx={{
-              height: 'fit-content',
-              padding: '2.5rem',
-              display: 'grid',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-            }}
-          >
+            <Box sx={{ width: '100%' }}>
+              <Box sx={{ typography: 'h6', fontWeight: '700', width: '100%' }}>
+                New Semester
+              </Box>
+              <Typography sx={{ width: '100%', maxWidth: '625px' }}>
+                This will add a new semester from the list of semesters you can
+                change to.
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexFlow: 'row wrap',
+                  gap: '20px',
+                  alignItems: 'center',
+                }}
+              >
+                <DropdownSelect
+                  sx={{ mb: '8px' }}
+                  value={selectedSeason}
+                  onChange={(event: SelectChangeEvent) => {
+                    setSelectedSeason(event.target.value)
+                  }}
+                >
+                  {semesterKeys.map((semester) => (
+                    <MenuItem key={semester} value={semester}>
+                      {semester}
+                    </MenuItem>
+                  ))}
+                </DropdownSelect>
+                <TextField
+                  label="Year"
+                  variant="outlined"
+                  type={'number'}
+                  value={year}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setYear(event.target.value)
+                  }}
+                />
+                <IconButton onClick={addSemester}>
+                  <AddIcon />
+                </IconButton>
+              </Box>
+            </Box>
             <Box
               sx={{
-                pl: '2.5rem',
-                pr: '2.5rem',
-                display: 'grid',
-                alignItems: 'center',
+                height: 'fit-content',
+                display: 'flex',
+                flexFlow: 'column nowrap',
               }}
             >
-              <Box sx={{ typography: 'h5', pr: '2rem' }}>Open Survey</Box>
+              <Box
+                sx={{
+                  typography: 'h6',
+                  fontWeight: '700',
+                  width: '100%',
+                }}
+              >
+                Survey Status
+              </Box>
+              <Typography sx={{ width: '100%', maxWidth: '625px', mb: '8px' }}>
+                This settings turns off and on the survey that students can fill
+                out to request new study partners.
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexFlow: 'row nowrap',
+                  gap: '32px',
+                  alignItems: 'center',
+                }}
+              >
+                <Typography> Off </Typography>
+                <Switch
+                  checked={surveyState}
+                  onChange={changeSurveyAvailability}
+                  sx={{
+                    size: 'lg',
+                    scale: '1.8',
+                  }}
+                />
+                <Typography> On </Typography>
+              </Box>
             </Box>
-            <Switch
-              checked={surveyState}
-              onChange={changeSurveyAvailability}
-              sx={{
-                marginLeft: 'auto',
-                marginRight: 'auto',
-                size: 'lg',
-                top: '1.9rem',
-                scale: '1.8',
-              }}
-            />
           </Box>
         </Box>
       </Box>
@@ -239,17 +287,14 @@ export const Settings = () => {
           width: '100%',
           height: 'fit-content',
           display: 'flex',
-          flexDirection: 'column',
+          flexFlow: 'column nowrap',
           justifyContent: 'space-between',
-          padding: '1rem',
-          pl: '5rem',
         }}
       >
         <Box
           sx={{
             typography: 'h4',
             fontWeight: 'bold',
-            left: '90rem',
             pt: '3rem',
           }}
         >

--- a/frontend/src/modules/Settings/Components/Settings.tsx
+++ b/frontend/src/modules/Settings/Components/Settings.tsx
@@ -1,5 +1,13 @@
 import { DropdownSelect } from '@core/index'
-import { Box, IconButton, SelectChangeEvent, Switch } from '@mui/material'
+import {
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  SelectChangeEvent,
+  Switch,
+  TextField,
+} from '@mui/material'
 import MenuItem from '@mui/material/MenuItem'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -11,6 +19,8 @@ import { AdministratorsTable } from './AdministratorsTable'
 import { Admin } from './types'
 import axios from 'axios'
 
+const semesterKeys: string[] = ['WI', 'SP', 'SU', 'FA']
+
 export const Settings = () => {
   const [currRoster, setCurrRoster] = useState<string>('')
   const changeCurrRoster = async (event: SelectChangeEvent) => {
@@ -21,22 +31,40 @@ export const Settings = () => {
     })
   }
 
+  const [selectedSeason, setSelectedSeason] = useState<string>('WI')
+  const [year, setYear] = useState<string>(
+    String(new Date().getFullYear()).substring(2, 4)
+  )
+
   const [semesters, setSemesters] = useState<string[]>([])
-  const [surveyState, setSurveyState] = useState<boolean>()
+  const [surveyState, setSurveyState] = useState<boolean>(false)
   const getAllSemesters = async () => {
     axios
       .get(`${API_ROOT}${COURSE_API}/semester/all`)
       .then((res) => setSemesters(res.data))
   }
+
   const getCurrSurveyState = async () => {
     await axios.get(`${API_ROOT}${COURSE_API}/semester/survey`).then((req) => {
       setSurveyState(req.data)
     })
   }
+
   const getCurrSemester = async () => {
     await axios.get(`${API_ROOT}${COURSE_API}/semester/current`).then((req) => {
       setCurrRoster(req.data)
     })
+  }
+
+  const addSemester = () => {
+    axios
+      .post(`${API_ROOT}/global/semester`, {
+        semester: selectedSeason + year,
+      })
+      .then(() => {
+        setSemesters(semesters.concat(selectedSeason + year))
+      })
+      .catch((err) => console.log(err))
   }
 
   const changeSurveyAvailability = async () => {
@@ -148,6 +176,30 @@ export const Settings = () => {
                 </MenuItem>
               ))}
             </DropdownSelect>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
+              <DropdownSelect
+                value={selectedSeason}
+                onChange={(event: SelectChangeEvent) => {
+                  setSelectedSeason(event.target.value)
+                }}
+              >
+                {semesterKeys.map((semester) => (
+                  <MenuItem key={semester} value={semester}>
+                    {semester}
+                  </MenuItem>
+                ))}
+              </DropdownSelect>
+              <TextField
+                label="Year"
+                variant="outlined"
+                type={'number'}
+                value={year}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setYear(event.target.value)
+                }}
+              />
+              <Button onClick={addSemester}>Add semester</Button>
+            </Box>
           </Box>
           <Box
             sx={{
@@ -178,7 +230,7 @@ export const Settings = () => {
                 top: '1.9rem',
                 scale: '1.8',
               }}
-            ></Switch>
+            />
           </Box>
         </Box>
       </Box>
@@ -207,7 +259,7 @@ export const Settings = () => {
           data={administrators}
           removeAdmin={removeAdmin}
           editAdmin={editAdmin}
-        ></AdministratorsTable>
+        />
       </Box>
     </Box>
   )

--- a/frontend/src/modules/Settings/Components/Settings.tsx
+++ b/frontend/src/modules/Settings/Components/Settings.tsx
@@ -12,39 +12,46 @@ import { Admin } from './types'
 import axios from 'axios'
 
 export const Settings = () => {
-  const [currRoster, setCurrRoster] = useState<string>('SP23')
-  const changeCurrRoster = (event: SelectChangeEvent) => {
+  const [currRoster, setCurrRoster] = useState<string>('')
+  const changeCurrRoster = async (event: SelectChangeEvent) => {
     // function to only open the survey of the semester
     setCurrRoster(event.target.value)
+    await axios.post(`${API_ROOT}${COURSE_API}/semester/current`, {
+      semester: event.target.value,
+    })
   }
 
   const [semesters, setSemesters] = useState<string[]>([])
-  function getAllSemesters() {
+  const [surveyState, setSurveyState] = useState<boolean>()
+  const getAllSemesters = async () => {
     axios
       .get(`${API_ROOT}${COURSE_API}/semester/all`)
       .then((res) => setSemesters(res.data))
   }
+  const getCurrSurveyState = async () => {
+    await axios.get(`${API_ROOT}${COURSE_API}/semester/survey`).then((req) => {
+      setSurveyState(req.data)
+    })
+  }
+  const getCurrSemester = async () => {
+    await axios.get(`${API_ROOT}${COURSE_API}/semester/current`).then((req) => {
+      setCurrRoster(req.data)
+    })
+  }
 
-  const [surveyState, setSurveyState] = useState<boolean>()
-
-  const changeSurveyAvailability = () => {
+  const changeSurveyAvailability = async () => {
     axios.post(`${API_ROOT}${COURSE_API}/semester/survey`, {
       surveyOpen: !surveyState,
     })
     setSurveyState(!surveyState)
   }
 
-  const getCurrSurveyState = async () => {
-    await axios.get(`${API_ROOT}${COURSE_API}/semester/survey`).then((req) => {
-      setSurveyState(req.data)
-    })
-  }
-
   useEffect(() => {
     getAllSemesters()
     changeSurveyAvailability()
-    getAdministrators()
     getCurrSurveyState()
+    getCurrSemester()
+    getAdministrators()
   }, [])
 
   const [administrators, setAdministrators] = useState<Admin[]>([])

--- a/frontend/src/modules/Settings/Components/Settings.tsx
+++ b/frontend/src/modules/Settings/Components/Settings.tsx
@@ -4,6 +4,7 @@ import {
   Grid,
   IconButton,
   SelectChangeEvent,
+  Snackbar,
   Switch,
   TextField,
   Typography,
@@ -11,7 +12,7 @@ import {
 import MenuItem from '@mui/material/MenuItem'
 import AddIcon from '@mui/icons-material/Add'
 
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { DASHBOARD_PATH } from '@core'
 import { ReactComponent as LogoImg } from '@assets/img/lscicon.svg'
@@ -22,6 +23,8 @@ import { Admin } from './types'
 import axios from 'axios'
 
 const semesterKeys: string[] = ['WI', 'SP', 'SU', 'FA']
+
+// TODO: deduplicat this
 const semValueMap = new Map([
   ['WI', 0],
   ['SP', 1],
@@ -75,6 +78,7 @@ export const Settings = () => {
     })
   }
 
+  const [semesterAdded, setSemesterAdded] = useState<boolean>(false)
   const addSemester = () => {
     axios
       .post(`${API_ROOT}/global/semester`, {
@@ -87,6 +91,7 @@ export const Settings = () => {
             ? semesters.concat(selectedSeason + year).sort(sortSemesters)
             : semesters
         )
+        setSemesterAdded(true)
       })
       .catch((err) => console.log(err))
   }
@@ -323,6 +328,12 @@ export const Settings = () => {
           editAdmin={editAdmin}
         />
       </Box>
+      <Snackbar
+        open={semesterAdded}
+        autoHideDuration={6000}
+        onClose={() => setSemesterAdded(false)}
+        message="Successfully added semester!"
+      />
     </Box>
   )
 }

--- a/frontend/src/modules/Settings/Components/Settings.tsx
+++ b/frontend/src/modules/Settings/Components/Settings.tsx
@@ -18,12 +18,6 @@ export const Settings = () => {
     setCurrRoster(event.target.value)
   }
 
-  useEffect(() => {
-    getAllSemesters()
-    changeSurveyAvailability()
-    getAdministrators()
-  }, [])
-
   const [semesters, setSemesters] = useState<string[]>([])
   function getAllSemesters() {
     axios
@@ -45,6 +39,13 @@ export const Settings = () => {
       setSurveyState(req.data)
     })
   }
+
+  useEffect(() => {
+    getAllSemesters()
+    changeSurveyAvailability()
+    getAdministrators()
+    getCurrSurveyState()
+  }, [])
 
   const [administrators, setAdministrators] = useState<Admin[]>([])
 

--- a/frontend/src/modules/Survey/Components/StepFail.tsx
+++ b/frontend/src/modules/Survey/Components/StepFail.tsx
@@ -13,29 +13,63 @@ export const StepFail = () => {
     fontSize: { sm: 14, md: 22 },
     mt: '1.25em',
     p: '0.24em 1em',
-    boxShadow: 1,
   }
 
   const Error = () => {
     return (
       <>
-        <Typography
+        <Box
           sx={{
-            fontSize: { xs: '2rem', md: '2.25rem' },
-            fontWeight: '700',
-            color: '#fff',
+            display: 'flex',
+            flexFlow: 'row nowrap',
+            gap: '60px',
+            justifyContent: 'center',
+            alignItems: 'center',
           }}
         >
-          The survey is closed
-        </Typography>
+          <Typography
+            sx={{
+              fontSize: { xs: '6rem', md: '8.5rem' },
+              fontWeight: '700',
+              color: '#fff',
+            }}
+          >
+            ):
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: { xs: '3rem', md: '4.25rem' },
+              fontWeight: '700',
+              color: '#fff',
+            }}
+          >
+            The Survey Is Currently Closed
+          </Typography>
+        </Box>
         <Typography
           sx={{
             color: '#fff',
             fontSize: '1.15rem',
+            fontWeight: '500',
           }}
         >
-          {' '}
-          Lookout for when the survey is open next semester!
+          We apologize for any inconvenience, but the survey for finding study
+          partners is currently closed for this semester. The survey should open
+          up again next semester! Please check back then. Thank you for your
+          interest!
+        </Typography>
+        <Typography
+          sx={{
+            fontWeight: '500',
+            color: '#fff',
+            fontSize: '1.15rem',
+          }}
+        >
+          Please Contact{' '}
+          <a href="mailto:lscstudypartners@cornell.edu">
+            lscstudypartners@cornell.edu
+          </a>{' '}
+          with any questions or any special one-off circumstances.
         </Typography>
       </>
     )
@@ -69,46 +103,26 @@ export const StepFail = () => {
           width: '100%',
           justifyContent: 'center',
           alignItems: 'center',
+          p: '0 15%',
         }}
       >
         <Box
           sx={{
-            maxWidth: '698px',
+            maxWidth: '1098px',
             display: 'flex',
             flexFlow: 'column wrap',
             gap: '48px',
             justifyContent: 'center',
-            alignItems: 'center',
+            alignItems: 'left',
           }}
         >
           {<Error />}
         </Box>
       </Box>
 
-      <Button
-        color="primary"
-        variant="outlined"
-        href="https://lsc.cornell.edu/"
-        sx={buttonStyle}
-      >
+      <Button color="inherit" href="https://lsc.cornell.edu/" sx={buttonStyle}>
         Back to Learning Strategies Center
       </Button>
-
-      <Typography
-        sx={{
-          fontWeight: '400',
-          color: '#fff',
-          fontSize: { xs: '1.15rem', xl: '1.75rem' },
-          margin: '4% 0',
-          maxWidth: '699px',
-        }}
-      >
-        Contact{' '}
-        <a href="mailto:lscstudypartners@cornell.edu">
-          lscstudypartners@cornell.edu
-        </a>{' '}
-        with any questions.
-      </Typography>
     </Box>
   )
 }

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -21,7 +21,7 @@ export const Survey = () => {
   const [currSurveyState, setCurrSurveyState] = useState<boolean>(true)
 
   function getCurrSurveyState() {
-    axios.get(`${API_ROOT}${COURSE_API}/semester/survey`).then((req) => {
+    axios.get(`${API_ROOT}/global/semester/survey`).then((req) => {
       setCurrSurveyState(req.data)
       console.log(req.data)
     })

--- a/frontend/src/modules/Survey/Components/Survey.tsx
+++ b/frontend/src/modules/Survey/Components/Survey.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import { Question } from '@core/Types'
 import { API_ROOT, STUDENT_API, COURSE_API } from '@core/Constants'
@@ -26,7 +26,11 @@ export const Survey = () => {
       console.log(req.data)
     })
   }
-  getCurrSurveyState()
+
+  useEffect(() => {
+    getCurrSurveyState()
+    console.log(`Survey Status is currently ${currSurveyState}`)
+  }, [])
 
   // Final step data
   const [surveySubmissionResponse, setSurveySubmissionResponse] = useState<


### PR DESCRIPTION
# Summary 

This PR addresses some bug fixes for the settings page and styling updates. 

- [x] Creates a 'global' router that does not require authorization so that student pages can access backend endpoints necessary for functionality. 

> 
> ### Example: 
> the ability to hit the get survey status endpoint (there is no logged-in user, hence no auth) 
> ### Note: 
> I named it global here for the sake of getting something pushed out, I was considering something like `public` (can be confused with the standard public folder for frontend assets) or `utils` (already used). 
> Could change this: because also Richard's PR is also refactoring the backend folders and functions 
> 



- [x] Adds Settings to the account menu dropdown 
- [x] Initializes states correctly now 
- [x] updates the backend state as well; not just local 
- [x] Clarify semester viewing vs. settings changing global 
- [x] Styling enhancement for the survey closed 
- [x] styling for the dashboard a bit so no overflow 

# Notes
I kind of don't like the toggling of survey status - makes it too easy to change something that is kind of important/shouldn't be easily changed. I feel like it should have a security mechanism - some confirmation module or a drop-down or something else - could change this in a future PR. 

We also would have to train/inform/document to LSC on how the different semester switching things work (global vs local views).

Things that may need a change in the future: 
- global router be refactored 
- settings page styling 
- how we implement survey status toggling 
- clarify switching semester view vs. switching semester globally 


# Testing 
https://user-images.githubusercontent.com/46132945/234050809-8f078a07-60ec-46d2-9069-3e5abe268849.mov

### New Settings Page Preview: 
<img width="1586" alt="image" src="https://user-images.githubusercontent.com/46132945/234172166-27801ef6-53fb-4056-a5b3-be143587abe4.png">
