### PR TITLE
Added groupId to Emails

### DIFF
--- a/frontend/src/modules/EditZing/Components/EmailModal.tsx
+++ b/frontend/src/modules/EditZing/Components/EmailModal.tsx
@@ -96,13 +96,13 @@ export const EmailModal = ({
 
     const groupTemplate =
       allGroupTemplates.find((template) => template.groupNumber === groupNumber)
-        ?.template.html || replacedHtml
+        ?.template.html + group.groupId || replacedHtml + group.groupId
 
     return Object.entries(replaceNamesMap).reduce(
       (prev, [key, value]) => prev.replaceAll(key, value),
       allGroupTemplates.find(
         (groupTemplate) => groupTemplate.groupNumber === groupNumber
-      )?.template.html || selectedTemplate.html
+      )?.template.html + group.groupId || selectedTemplate.html + group.groupId
     )
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->

Added groupId as the last line of an email by LSC so that LSC knows which group they are emailing. 

### Test Plan <!-- Required -->
Tested that the right groupId showed up for each group and that they were different. Tested that the groupId does not show up for the no match templates and the individual emails.

![Screenshot 2023-04-23 at 1 51 37 PM](https://user-images.githubusercontent.com/94809605/234118031-7df54491-f29c-4bc4-b24d-73c6fbeef80e.png)
![Screenshot 2023-04-23 at 1 54 40 PM](https://user-images.githubusercontent.com/94809605/234118172-bea96c2b-a4d7-474c-94ac-6366e7cfbf78.png)



### Notes <!-- Optional -->


### Breaking Changes <!-- Optional -->

