### PR TITLE
Added edge case for no match session closed

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -81,7 +81,10 @@ export const Dashboard = () => {
     if (!group) {
       throw Error(`Student with email ${smail} not found in course ${courseId}`)
     }
-    return !group.templateTimestamps['no-match-yet']
+    return (
+      !group.templateTimestamps['no-match-yet'] &&
+      !group.templateTimestamps['no-match-session-closed']
+    )
   }
 
   //Helper function that returns true if an unmatched student in a course doesn't have a no match email


### PR DESCRIPTION
### Summary <!-- Required -->

- added edge case for no match session closed filter
- checked if the template timestamp key no-match-session-closed was undefined or not and added it as a condition to the studentHasUnsentNoMatch function

### Test Plan <!-- Required -->

- tested sending both no-match-session-closed and no-match emails
- tested filtering on no no match emails and other filters
