### PR TITLE
Survey uses current semester setting instead of a hardcoded default

### DIFF
--- a/backend/functions/src/student/functions.ts
+++ b/backend/functions/src/student/functions.ts
@@ -7,6 +7,7 @@ import {
 } from '../course/get_course_id'
 import { mapDate } from '../course/functions'
 import { FirestoreStudent, Student } from '../types'
+import { getCurrentSemester } from '../settings/functions'
 const courseRef = db.collection('courses')
 const studentRef = db.collection('students')
 
@@ -104,7 +105,7 @@ export const addStudentSurveyResponse = async (
   courseCatalogNames: string[],
   surveySubmittable: boolean
 ) => {
-  const roster = 'SP23' // Spring 2023
+  const roster = await getCurrentSemester()
 
   if (!surveySubmittable) {
     throw new Error('Survey is Closed')


### PR DESCRIPTION
### Summary <!-- Required -->

LSC reported that despite changing the semester, SP23 was still showing. This was because in the backend, the roster defaulted to a hardcoded string rather than the dynamic setting we now have. This PR fixes that.

### Test Plan <!-- Required -->

Local run to change semester, then submit survey to see if issue is still there.

![image](https://github.com/cornell-dti/zing-lsc/assets/69130822/9fa706f6-c20f-4359-b809-7a843bc30e13)
