### PR TITLE
Metrics now automatically update with new semesters

### DIFF
--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -12,9 +12,11 @@ import { DASHBOARD_PATH } from '@core/Constants'
 import { Link } from 'react-router-dom'
 import { GroupMembership } from '@core'
 import survey from '@core/Questions/Questions.json'
+import { useSettingsValue } from '@context/SettingsContext'
 
 export const Metrics = () => {
-  const { courses } = useCourseValue()
+  const { currRoster } = useSettingsValue()
+  const { courses, semesters } = useCourseValue()
   const { students } = useStudentValue()
 
   //checks if date is within the week (beginning of the day Sunday to end of day Saturday)
@@ -46,7 +48,7 @@ export const Metrics = () => {
     )
   }
 
-  const [selectedRoster, setSelectedRoster] = useState<string>('SP23')
+  const [selectedRoster, setSelectedRoster] = useState<string>(currRoster)
   const studentsInSemester = new Map<
     string,
     { semester: string; groups: GroupMembership[]; college: string }
@@ -292,14 +294,11 @@ export const Metrics = () => {
             alignSelf: 'flex-end',
           }}
         >
-          <MenuItem value="SU22">Summer 2022</MenuItem>
-          <MenuItem value="FA22">Fall 2022</MenuItem>
-          <MenuItem value="WI23">Winter 2023</MenuItem>
-          <MenuItem value="SP23">Spring 2023</MenuItem>
-          <MenuItem value="SU23">Summer 2023</MenuItem>
-          <MenuItem value="FA23">Fall 2023</MenuItem>
-          <MenuItem value="WI24">Winter 2024</MenuItem>
-          <MenuItem value="SP24">Spring 2024</MenuItem>
+          {semesters.map((sem) => (
+            <MenuItem key={sem} value={sem}>
+              {sem}
+            </MenuItem>
+          ))}
         </DropdownSelect>
       </Box>
       <MetricsTable

--- a/frontend/src/modules/Metrics/Components/Metrics.tsx
+++ b/frontend/src/modules/Metrics/Components/Metrics.tsx
@@ -297,7 +297,9 @@ export const Metrics = () => {
           <MenuItem value="WI23">Winter 2023</MenuItem>
           <MenuItem value="SP23">Spring 2023</MenuItem>
           <MenuItem value="SU23">Summer 2023</MenuItem>
-          <MenuItem value="WI24:">Winter 2024</MenuItem>
+          <MenuItem value="FA23">Fall 2023</MenuItem>
+          <MenuItem value="WI24">Winter 2024</MenuItem>
+          <MenuItem value="SP24">Spring 2024</MenuItem>
         </DropdownSelect>
       </Box>
       <MetricsTable


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Previously when we moved to a new semester, someone needed to manually change the codebase in order to make that semester available to be viewed on the metrics page. 

- [x] Newly added semesters automatically also get added to metrics
- [x] Metrics page automatically loads with the current semester set by in the settings  

### Test Plan <!-- Required -->

Originally on the metrics page there isn't an option for Spring 25. 
<img width="1643" alt="Screenshot 2024-02-15 at 12 26 11 AM" src="https://github.com/cornell-dti/zing-lsc/assets/64031655/35d1883b-935d-4658-801a-ea25337cc126">

I can now add the Spring 25 semester via the settings. 
<img width="789" alt="Screenshot 2024-02-15 at 12 27 03 AM" src="https://github.com/cornell-dti/zing-lsc/assets/64031655/0350fd75-0f2e-4947-8ab6-b463263ecd12">

And now it is available as an option. 
<img width="1675" alt="Screenshot 2024-02-15 at 12 29 06 AM" src="https://github.com/cornell-dti/zing-lsc/assets/64031655/f815c8fc-aef6-4598-a2b9-ac2ecd8df17f">


### Notes <!-- Optional -->

The dropdown menu of the metrics page has the abbreviation semester "SP", rather than the the fully spelled out word "spring". 

### Breaking Changes <!-- Optional -->