### PR TITLE
fixed check-in filter on frontend

### DIFF
--- a/frontend/src/modules/Dashboard/Components/Dashboard.tsx
+++ b/frontend/src/modules/Dashboard/Components/Dashboard.tsx
@@ -70,7 +70,7 @@ export const Dashboard = () => {
   )
   //Helper function to check if a given course has any groups without check-in emails
   function hasUnsentCheckIns(c: Course) {
-    return c.groups.some((group) => !group.templateTimestamps['check-in'])
+    return c.groups.some((group) => !group.templateTimestamps['1check-in'])
   }
 
   //Helper function that returns true if the student doesn't have a no match email


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the bug that the "no check-in" filter was showing classes in which all groups were already sent a check-in email. 

This bug stemmed from the fact that in order to display the order of email templates accurately in the send email modal, the backend fields were updated with numbers to reflect that order of email templates alphanumerically, rather than fixing the order on the frontend. Although this field name was changed in the database, it was not reflected in the filter logic. In this PR, filter logic was then updated to reflect the updated field. 

<img width="605" alt="Screenshot 2024-03-05 at 1 50 03 PM" src="https://github.com/cornell-dti/zing-lsc/assets/64031655/26891367-af68-4986-89a1-cd64ad2b0d35">

### Test Plan <!-- Required -->

In this example, ECON 1110 and PHYS 2213 students were matched, and updated the `templateTimestamps` field in the emulator database through the backend for ECON 1100. This was done through calling the `updateGroupTimestamp` in `backend/functions/src/emailing/functions.ts`.

Since the Microsoft Graph PR (https://github.com/cornell-dti/zing-lsc/pull/165) was not merged, I was not able to use the emailing feature via the frontend, which is why I called the backend function instead so that the database can update appropriately. 

<img width="1707" alt="Screenshot 2024-03-05 at 1 29 14 PM" src="https://github.com/cornell-dti/zing-lsc/assets/64031655/1fa94d41-3cca-433d-86a0-3a72eab76b4d">

After applying the filter, ECON 1100 no longer shows up when applying the "no checkin email" filter, as expected.

<img width="1389" alt="Screenshot 2024-03-05 at 1 38 35 PM" src="https://github.com/cornell-dti/zing-lsc/assets/64031655/065197f9-4707-4c80-95dc-c150edc3a58f">


### Notes <!-- Optional -->

This change has no affect on the ability of the system to get email templates. Although the id for the check-in email is `check-in`, it is still able to retrieve the correct email template since the filter does not communicate with the email templates.

### Breaking Changes <!-- Optional -->